### PR TITLE
Pipelining the response into new-wrapper object wasn't working

### DIFF
--- a/src/GitlabCli/MergeRequests.psm1
+++ b/src/GitlabCli/MergeRequests.psm1
@@ -223,8 +223,9 @@ function Update-GitlabMergeRequest {
         $Query['description'] = $Description
     }
 
-    Invoke-GitlabApi PUT "projects/$ProjectId/merge_requests/$MergeRequestId" $Query -WhatIf:$WhatIf |
-        New-WrapperObject $_ -DisplayType 'Gitlab.MergeRequest'
+    $result = Invoke-GitlabApi PUT "projects/$ProjectId/merge_requests/$MergeRequestId" $Query -WhatIf:$WhatIf
+    New-WrapperObject $result -DisplayType 'Gitlab.MergeRequest'
+
 }
 
 function Close-GitlabMergeRequest {


### PR DESCRIPTION
When Attempting to use `Close-GitlabMergeRequest` I received the error below

```powershell
Line |
 227 |          New-WrapperObject $_ -DisplayType 'Gitlab.MergeRequest'
     |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | The input object cannot be bound to any parameters for the command either because the command does not take pipeline input or the input and its properties do not match any
     | of the parameters that take pipeline input.
```

Determined that this was the result of piping the `Invoke-GitlabApi` response into Wrap object without a foreach.