### PR TITLE
Disabling ci workflow for forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    if: github.repository == 'chris-peterson/pwsh-gitlab'
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This adds an `if:` condition to not run the build/publish of the module. This is putting Actions noise in the forks.