### PR TITLE
Add file-based configuration option

### DIFF
--- a/src/GitlabCli/Config.psm1
+++ b/src/GitlabCli/Config.psm1
@@ -1,0 +1,137 @@
+function Set-DefaultGitlabCliSystem {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string]
+        $Name
+    )
+
+    $configuration = Get-GitlabCliConfig
+    if($configuration.FromEnvironment) {
+        Write-Warning "Unsupported: Current configuration is from environment variables."
+        Write-Warning "Unset `$env:GITLAB_ACCESS_TOKEN and `$env:GITLAB_URL"
+        return $configuration
+    }
+
+    if($configuration[$Name] -ne $null ) {
+        $configuration.DefaultSite = $Name
+        return Write-GitlabCliConfig $configuration
+    }
+
+    Write-Warning "System with $($Name) doesn't exist"
+    return $configuration
+}
+
+function Add-GitlabCliSystem {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name,
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Token
+    )
+        
+    $configuration = Get-GitlabCliConfig
+
+    if($configuration.FromEnvironment) {
+        Write-Warning "Unsupported: Current configuration is from environment variables."
+        Write-Warning "Unset `$env:GITLAB_ACCESS_TOKEN and `$env:GITLAB_URL"
+        return $configuration
+    }
+
+    if($configuration[$Name] -ne $null) {
+        if($configuration[$Name].ApiToken -ne $Token) {
+            Write-Host "A token already exists for $Name"
+            $response = $(Read-Host -Prompt "Would you like to replace it? [y/n]")
+            if($response -imatch "y") {
+                $configuration[$Name].ApiToken = $Token
+                Write-GitlabCliConfig $configuration
+            } else {
+                Write-Host "Information already exists"
+                return $configuration
+            }
+        }
+    }
+
+    $configuration[$Name] = @{
+        ApiToken = $Token
+    }
+
+    return Write-GitlabCliConfig $configuration
+}
+
+function Remove-GitlabCliSystem {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [string]
+        $Name
+    )
+
+    $configuration = Get-GitlabCliConfig
+    if($configuration.FromEnvironment) {
+        Write-Warning "Unsupported: Current configuration is from environment variables."
+        Write-Warning "Unset `$env:GITLAB_ACCESS_TOKEN and `$env:GITLAB_URL"
+        return
+    }
+
+    if($configuration[$Name] -eq $null) {
+        Write-Warning "No entry for $($Name)"
+    }
+
+    $configuration.Remove($Name)
+    return Write-GitlabCliConfig $configuration
+}
+
+function Write-GitlabCliConfig {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [hashtable]
+        $configuration
+    )
+
+    Get-GitlabCliConfig | Out-Null
+    
+    Clear-Content $Global:GitlabCliConfigPath
+    $configuration | ConvertTo-Json | Add-Content $Global:GitlabCliConfigPath
+    return $configuration
+}
+
+function Get-GitlabCliConfig {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string]
+        $ConfigRoot = "$($env:HOME)/.gitlabcli",
+        
+        [Parameter()]
+        [string]
+        $ConfigName = "config.json"
+    )
+
+    if($env:GITLAB_URL -ne $null -and $env:GITLAB_ACCESS_TOKEN -ne $null) {
+        return @{
+            "DefaultSite"=$env:GITLAB_URL
+            "$($env:GITLAB_URL)" = @{
+                ApiToken = $env:GITLAB_ACCESS_TOKEN
+            }
+
+            FromEnvironment=$true
+        }
+    }
+
+    $configPath = "$($ConfigRoot)/$($ConfigName)"
+    $Global:GitlabCliConfigPath = $configPath
+
+    if(-NOT (Test-Path $configPath)) {
+        if(-NOT(Test-Path $ConfigRoot)) {
+            mkdir $ConfigRoot
+        }
+        Add-Content $configPath "{`"DefaultSite`": `"`" }" -Force        
+    }
+
+    return Get-Content $configPath | ConvertFrom-Json -AsHashtable
+}

--- a/src/GitlabCli/GitlabCli.psd1
+++ b/src/GitlabCli/GitlabCli.psd1
@@ -60,6 +60,7 @@
     # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
     NestedModules = @(
         'Branches.psm1'
+        'Config.psm1'
         'Deployments.psm1'
         'Environments.psm1'
         'Git.psm1'
@@ -86,6 +87,7 @@
         'Remove-GitlabCliSystem'
         'Add-GitlabCliSystem'
         'Get-GitlabCliConfig'
+        'Set-DefaultGitlabCliSystem'
         
         # Groups
         'Get-GitlabGroup'

--- a/src/GitlabCli/GitlabCli.psd1
+++ b/src/GitlabCli/GitlabCli.psd1
@@ -81,6 +81,11 @@
 
         # Branches    
         'Get-GitlabBranch'
+
+        # Configuration
+        'Remove-GitlabCliSystem'
+        'Add-GitlabCliSystem'
+        'Get-GitlabCliConfig'
         
         # Groups
         'Get-GitlabGroup'

--- a/src/GitlabCli/MergeRequests.psm1
+++ b/src/GitlabCli/MergeRequests.psm1
@@ -59,6 +59,8 @@ function Get-GitlabMergeRequest {
         $WhatIf
     )
 
+    $configuration = Get-GitlabCliConfig
+
     $Path = $null
     $MaxPages = 1
     $Query = @{}
@@ -67,7 +69,7 @@ function Get-GitlabMergeRequest {
         $Path = 'merge_requests'
     }
     else {
-        if ($Url -and $Url -match "$env:GITLAB_URL/(?<ProjectId>.*)/-/merge_requests/(?<MergeRequestId>\d+)") {
+        if ($Url -and $Url -match "$($configuration.DefaultSite)/(?<ProjectId>.*)/-/merge_requests/(?<MergeRequestId>\d+)") {
             $ProjectId = $Matches.ProjectId
             $MergeRequestId = $Matches.MergeRequestId
         }

--- a/src/GitlabCli/Utilities.psm1
+++ b/src/GitlabCli/Utilities.psm1
@@ -50,13 +50,16 @@ function Invoke-GitlabApi {
     $Headers = @{
         'Accept' = 'application/json'
     }
-    if ($env:GITLAB_ACCESS_TOKEN) {
-        $Headers['Authorization'] = "Bearer $env:GITLAB_ACCESS_TOKEN"
+
+    $configuration = Get-GitlabCliConfig
+    $defaultSiteApiToken = $configuration[$configuration.DefaultSite].ApiToken
+    if ($defaultSiteApiToken) {
+        $Headers['Authorization'] = "Bearer $defaultSiteApiToken"
     } else {
-        Write-Error "`$env:GITLAB_ACCESS_TOKEN` has not been configured`nSee https://github.com/chris-peterson/pwsh-gitlab#getting-started for details"
+        Write-Error "Add-GitlabCliSystem hasn't been executed or `$env:GITLAB_ACCESS_TOKEN` has not been configured`nSee https://github.com/chris-peterson/pwsh-gitlab#getting-started for details"
         return
     }
-    $GitlabUrl = $env:GITLAB_URL ?? 'gitlab.com'
+    $GitlabUrl = $configuration.DefaultSite
 
     if (-not $GitlabUrl.StartsWith('http')) {
         $GitlabUrl = "https://$GitlabUrl"


### PR DESCRIPTION
In response to Issue #11 
## New Commands

`Get-GitlabCliConfig`

`Add-GitlabCliSystem`
`Remove-GitlabCliSystem`
`Set-DefaultGitlabCliSystem`

All commands return the configuration object
## Old environment variables behavior preserved

`$env:GITLAB_ACCESS_TOKEN` and `$env:GITLAB_URL`  take precedence over the config values. This should preserve all existing behavior/installations

In the event that the configuration is from environment variables. The configuration object will have a `FromEnvironment=True` on it.

All commands that manipulate the configuration will not work when the environment variables are set.


## CLI Output

When the config comes from the environment
```pwsh
> Get-GitlabCliConfig

Name                           Value
----                           -----
DefaultSite                    gitlab.com
gitlab.com                     {ApiToken}
FromEnvironment                True
```

From the config itself
```pwsh
>$env:GITLAB_URL=$null; $env:GITLAB_ACCESS_TOKEN=$null
> Get-GitlabCliConfig

Name                           Value
----                           -----
DefaultSite                    gitlab.com
gitlab.com                     {ApiToken}
gitlab.other.com               {ApiToken}
```

## Configuration at ~/.gitlabcli/config.json
```
{
  "DefaultSite": "gitlab.com",
  "gitlab.com": {
    "ApiToken": "xyz12345"
  },
  "gitlab.other.com": {
    "ApiToken": "8fhs63"
  }
}
```