### PR TITLE
Improve ability to navigate project and group hierarchies

### DIFF
--- a/src/GitlabCli/Formats.ps1xml
+++ b/src/GitlabCli/Formats.ps1xml
@@ -72,6 +72,37 @@
       </TableControl>
     </View>
     <View>
+      <Name>GitlabBranch</Name>
+      <ViewSelectedBy>
+        <TypeName>Gitlab.Branch</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader>
+          </TableColumnHeader>
+          <TableColumnHeader>
+          </TableColumnHeader>
+          <TableColumnHeader>
+          </TableColumnHeader>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>Name</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>LastAuthor</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>Url</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <View>
       <Name>GitlabIssue</Name>
       <ViewSelectedBy>
         <TypeName>Gitlab.Issue</TypeName>

--- a/src/GitlabCli/Formats.ps1xml
+++ b/src/GitlabCli/Formats.ps1xml
@@ -610,5 +610,29 @@
         </TableRowEntries>
       </TableControl>
     </View>
+    <View>
+      <Name>GitlabRepositoryFile</Name>
+      <ViewSelectedBy>
+        <TypeName>Gitlab.RepositoryFile</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader/>
+          <TableColumnHeader/>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>Name</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ItemType</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
   </ViewDefinitions>
 </Configuration>

--- a/src/GitlabCli/Formats.ps1xml
+++ b/src/GitlabCli/Formats.ps1xml
@@ -611,6 +611,30 @@
       </TableControl>
     </View>
     <View>
+      <Name>GitlabRepositoryTree</Name>
+      <ViewSelectedBy>
+        <TypeName>Gitlab.RepositoryTree</TypeName>
+      </ViewSelectedBy>
+      <TableControl>
+        <TableHeaders>
+          <TableColumnHeader/>
+          <TableColumnHeader/>
+        </TableHeaders>
+        <TableRowEntries>
+          <TableRowEntry>
+            <TableColumnItems>
+              <TableColumnItem>
+                <PropertyName>Name</PropertyName>
+              </TableColumnItem>
+              <TableColumnItem>
+                <PropertyName>ItemType</PropertyName>
+              </TableColumnItem>
+            </TableColumnItems>
+          </TableRowEntry>
+        </TableRowEntries>
+      </TableControl>
+    </View>
+    <View>
       <Name>GitlabRepositoryFile</Name>
       <ViewSelectedBy>
         <TypeName>Gitlab.RepositoryFile</TypeName>
@@ -627,7 +651,7 @@
                 <PropertyName>Name</PropertyName>
               </TableColumnItem>
               <TableColumnItem>
-                <PropertyName>ItemType</PropertyName>
+                <PropertyName>CommitId</PropertyName>
               </TableColumnItem>
             </TableColumnItems>
           </TableRowEntry>

--- a/src/GitlabCli/Git.psm1
+++ b/src/GitlabCli/Git.psm1
@@ -5,12 +5,16 @@ function Get-LocalGitContext {
         $Path = '.'
     )
     
-    Push-Location
     $Context = [PSCustomObject]@{
         Site = ''
         Project = ''
         Branch = ''
     }
+    if($(Get-Location).Provider.Name -ne 'FileSystem') {
+        return $Context
+    }
+
+    Push-Location
 
     try {
         Set-Location $Path

--- a/src/GitlabCli/GitlabCli.psd1
+++ b/src/GitlabCli/GitlabCli.psd1
@@ -118,6 +118,8 @@
         'Remove-GitlabProjectVariable'
 
         # Repository Files
+        'Get-GitlabRepositoryFile'
+        'Get-GitlabRepositoryTree'
         'Get-GitlabRepositoryFileContent'
         'Get-GitlabRepositoryYmlFileContent'
         'Get-GitlabCiYml'

--- a/src/GitlabCli/Groups.psm1
+++ b/src/GitlabCli/Groups.psm1
@@ -1,23 +1,45 @@
 function Get-GitlabGroup {
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName='ByGroupId')]
     param (
-        [Parameter(Position=0, Mandatory=$true)]
+        [Parameter(Position=0, Mandatory=$false, ParameterSetName='ByGroupId')]
         [string]
         $GroupId,
+
+        [Parameter(Mandatory=$true, ParameterSetName='ByParentGroup')]
+        [Alias('p')]
+        [string]
+        $ParentGroupId,
 
         [Parameter(Mandatory=$false)]
         [string]
         $SiteUrl,
 
+        [Parameter(Mandatory=$false)]
+        [Alias('r')]
+        [switch]
+        $Recurse,
+
         [switch]
         [Parameter(Mandatory=$false)]
         $WhatIf
     )
-
-    $Group = Invoke-GitlabApi GET "groups/$($GroupId | ConvertTo-UrlEncoded)" @{
-        'with_projects' = 'false'
-    } -SiteUrl $SiteUrl -WhatIf:$WhatIf
+    $MaxPages = 10
+    if($GroupId) {
+        $Group = Invoke-GitlabApi GET "groups/$($GroupId | ConvertTo-UrlEncoded)" @{
+            'with_projects' = 'false'
+        } -SiteUrl $SiteUrl -WhatIf:$WhatIf
+    }
+    elseif($ParentGroupId) {
+        $SubgroupOperation = $Recurse ? 'descendant_groups' : 'subgroups'
+        $Group = Invoke-GitlabApi GET "groups/$($ParentGroupId | ConvertTo-UrlEncoded)/$SubgroupOperation" `
+          -SiteUrl $SiteUrl -WhatIf:$WhatIf -MaxPages $MaxPages
+    }
+    else {
+        $Group = Invoke-GitlabApi GET "groups" @{
+            'top_level_only' = (-not $Recurse).ToString().ToLower()
+        } -MaxPages $MaxPages
+    }
 
     return $Group | New-WrapperObject 'Gitlab.Group'
 }

--- a/src/GitlabCli/Projects.psm1
+++ b/src/GitlabCli/Projects.psm1
@@ -10,6 +10,11 @@ function Get-GitlabProject {
         [string]
         $GroupId,
 
+        [Parameter(Mandatory=$false, ParameterSetName='ByGroup')]
+        [Alias('r')]
+        [switch]
+        $Recurse,
+
         [Parameter(Position=0, Mandatory=$true, ParameterSetName='ByUrl')]
         [string]
         $Url,
@@ -40,7 +45,7 @@ function Get-GitlabProject {
         ByGroup {
             $Group = Get-GitlabGroup $GroupId
             $Query = @{
-                'include_subgroups' = 'true'
+                'include_subgroups' = $Recurse ? 'true' : 'false'
             }
             if (-not $IncludeArchived) {
                 $Query['archived'] = 'false'

--- a/src/GitlabCli/RepositoryFiles.psm1
+++ b/src/GitlabCli/RepositoryFiles.psm1
@@ -27,17 +27,85 @@ function Get-GitlabRepositoryFileContent {
         $WhatIf
     )
 
+    $File = Get-GitlabRepositoryFile -ProjectId $ProjectId -FilePath $FilePath -Ref $Ref -SiteUrl $SiteUrl -WhatIf:$WhatIf
+    
+    if ($File -and $File.Encoding -eq 'base64') {
+        return [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($File.Content))
+    }
+}
+
+function Get-GitlabRepositoryFile {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$false)]
+        [string]
+        $ProjectId = '.',
+
+        [Parameter(Position=0, Mandatory=$true)]
+        [string]
+        $FilePath,
+
+        [Parameter(Mandatory=$false)]
+        [Alias("Branch")]
+        [string]
+        $Ref,
+
+        [Parameter(Mandatory=$false)]
+        [string]
+        $SiteUrl,
+
+        [switch]
+        [Parameter(Mandatory=$false)]
+        $WhatIf
+    )
+
     $Project = Get-GitlabProject $ProjectId
     if (-not $Ref) {
         $Ref = $Project.DefaultBranch
     }
     $RefName = $(Get-GitlabBranch -ProjectId $ProjectId -Ref $Ref).Name
 
-    $File = Invoke-GitlabApi GET "projects/$($Project.Id)/repository/files/$($FilePath | ConvertTo-UrlEncoded)?ref=$RefName" -SiteUrl $SiteUrl -WhatIf:$WhatIf
-    
-    if ($File -and $File.encoding -eq 'base64') {
-        [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($File.content))
+    return Invoke-GitlabApi GET "projects/$($Project.Id)/repository/files/$($FilePath | ConvertTo-UrlEncoded)?ref=$RefName" -SiteUrl $SiteUrl -WhatIf:$WhatIf |
+        New-WrapperObject 'Gitlab.RepositoryFile'
+}
+
+function Get-GitlabRepositoryTree {
+    param(
+        [Parameter(Mandatory=$false)]
+        [string]
+        $ProjectId = '.',
+
+        [Parameter(Position=0, Mandatory=$false)]
+        [string]
+        $Path,
+
+        [Parameter(Mandatory=$false)]
+        [Alias("Branch")]
+        [string]
+        $Ref,
+
+        [Parameter(Mandatory=$false)]
+        [Alias('r')]
+        [switch]
+        $Recurse,
+
+        [Parameter(Mandatory=$false)]
+        [string]
+        $SiteUrl,
+
+        [switch]
+        [Parameter(Mandatory=$false)]
+        $WhatIf
+    )
+
+    $Project = Get-GitlabProject $ProjectId
+    if (-not $Ref) {
+        $Ref = $Project.DefaultBranch
     }
+    $RefName = $(Get-GitlabBranch -ProjectId $ProjectId -Ref $Ref).Name
+
+    Invoke-GitlabApi GET "projects/$($Project.Id)/repository/tree?ref=$RefName&path=$Path&recursive=$($Recurse.ToString().ToLower())" -MaxPages 10 -SiteUrl $SiteUrl -WhatIf:$WhatIf |
+        New-WrapperObject 'Gitlab.RepositoryFile'
 }
 
 function Get-GitlabCiYml {

--- a/src/GitlabCli/RepositoryFiles.psm1
+++ b/src/GitlabCli/RepositoryFiles.psm1
@@ -105,7 +105,7 @@ function Get-GitlabRepositoryTree {
     $RefName = $(Get-GitlabBranch -ProjectId $ProjectId -Ref $Ref).Name
 
     Invoke-GitlabApi GET "projects/$($Project.Id)/repository/tree?ref=$RefName&path=$Path&recursive=$($Recurse.ToString().ToLower())" -MaxPages 10 -SiteUrl $SiteUrl -WhatIf:$WhatIf |
-        New-WrapperObject 'Gitlab.RepositoryFile'
+        New-WrapperObject 'Gitlab.RepositoryTree'
 }
 
 function Get-GitlabCiYml {

--- a/src/GitlabCli/Types.ps1xml
+++ b/src/GitlabCli/Types.ps1xml
@@ -3,6 +3,10 @@
   <Type>
     <Name>Gitlab.Branch</Name>
     <Members>
+      <ScriptProperty>
+        <Name>LastAuthor</Name>
+        <GetScriptBlock>$this.Commit[0].author_name</GetScriptBlock>
+      </ScriptProperty>
     </Members>
   </Type>
   <Type>

--- a/src/GitlabCli/Types.ps1xml
+++ b/src/GitlabCli/Types.ps1xml
@@ -192,11 +192,20 @@
     </Members>
   </Type>
   <Type>
-    <Name>Gitlab.RepositoryFile</Name>
+    <Name>Gitlab.RepositoryTree</Name>
     <Members>
       <ScriptProperty>
         <Name>ItemType</Name>
         <GetScriptBlock>$this.Type -eq 'tree' ? 'Directory' : 'File'</GetScriptBlock>
+      </ScriptProperty>
+    </Members>
+  </Type>
+  <Type>
+    <Name>Gitlab.RepositoryFile</Name>
+    <Members>
+      <ScriptProperty>
+        <Name>Name</Name>
+        <GetScriptBlock>$this.FileName</GetScriptBlock>
       </ScriptProperty>
     </Members>
   </Type>

--- a/src/GitlabCli/Types.ps1xml
+++ b/src/GitlabCli/Types.ps1xml
@@ -191,4 +191,13 @@
     <Members>
     </Members>
   </Type>
+  <Type>
+    <Name>Gitlab.RepositoryFile</Name>
+    <Members>
+      <ScriptProperty>
+        <Name>ItemType</Name>
+        <GetScriptBlock>$this.Type -eq 'tree' ? 'Directory' : 'File'</GetScriptBlock>
+      </ScriptProperty>
+    </Members>
+  </Type>
 </Types>


### PR DESCRIPTION
 - Adds `-Recurse` options to `Get-GitlabProject` and `Get-GitlabGroup`
 - Adds a `-ParentGroupId` option to `Get-GitlabGroup` to allow listing subgroups
 - Adds friendly visualization of the `GitlabBranch` object