### PR TITLE
Addresses Issue #17

### DIFF
--- a/src/GitlabCli/Jobs.psm1
+++ b/src/GitlabCli/Jobs.psm1
@@ -2,9 +2,8 @@
 function Get-GitlabJob {
     [Alias('job')]
     [Alias('jobs')]
-    [CmdletBinding(DefaultParameterSetName='ByProjectId')]
+    [CmdletBinding()]
     param (
-
         [Parameter(ParameterSetName='ByJobId', Mandatory=$false)]
         [Parameter(ParameterSetName='ByProjectId', Mandatory=$false, ValueFromPipelineByPropertyName=$true)]
         [Parameter(ParameterSetName='ByPipeline', Mandatory=$false, ValueFromPipelineByPropertyName=$true)]

--- a/src/GitlabCli/Pipelines.psm1
+++ b/src/GitlabCli/Pipelines.psm1
@@ -234,11 +234,11 @@ function Update-GitlabPipelineSchedule {
 function Get-GitlabPipelineBridges {
     [CmdletBinding()]
     param (
-        [Parameter(Mandatory=$true,Position=0)]
+        [Parameter(Mandatory=$false, ValueFromPipelineByPropertyName=$true)]
         [string]
-        $ProjectId,
+        $ProjectId = '.',
 
-        [Parameter(Mandatory=$true,Position=1)]
+        [Parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
         [string]
         $PipelineId,
 


### PR DESCRIPTION
Updates for some pipeline input issues

This was a result of `DefaultParameterSetName` being defined. once removed both usages worked fine

Now when you pipe any object matching the properties it'll work. Or it will fall back to previous pulling all the jobs in the project