### PR TITLE
Suppress bool object from returning in Get-LocalGitContext

### DIFF
--- a/src/GitlabCli/Git.psm1
+++ b/src/GitlabCli/Git.psm1
@@ -24,12 +24,13 @@ function Get-LocalGitContext {
             try {
                 $Uri = [Uri]::new($OriginUrl)
                 $Context.Site = $Uri.Host
-                $Uri.AbsolutePath -match '/?(?<Project>.*)'
+                $result = $Uri.AbsolutePath -match '/?(?<Project>.*)' 
                 $Context.Project = $Matches.Project -replace '.git$', ''
+              
             }
             catch {
                 # git
-                $OriginUrl -match '@(?<Site>.*?)(/|:)(?<Project>[a-zA-Z0-9/-]+)'
+                $result = $OriginUrl -match '@(?<Site>.*?)(/|:)(?<Project>[a-zA-Z0-9/-]+)'
                 $Context.Site = $Matches.Site
                 $Context.Project = $Matches.Project
             }


### PR DESCRIPTION
When executing Get-LocalGitlabContext it is returning a bool AND the context object. This results in non fatal error messages being displayed from other commands

`Get-LocalGitContext`
```
True

Site       Project                     Branch
----       -------                     ------
github.com CaseyMacPherson/pwsh-gitlab main
```

When using the command `Set-GitlabMergeRequest` alias `MR` the following output is observed. The table output isn't important, so the dots are just obfuscation ;)
```
Select-Object: Property "Branch" cannot be found.

  Id Author      Title         Url
  -- ------      -----        ---
  ..   ...            .....            .....
```

After this fix, `True` or `False` should no longer be observed in the output