### PR TITLE
Allow sending arbitrary content to CI validation API

### DIFF
--- a/src/GitlabCli/GitlabCli.psd1
+++ b/src/GitlabCli/GitlabCli.psd1
@@ -1,5 +1,5 @@
 @{
-    ModuleVersion = '1.29.2'
+    ModuleVersion = '1.30.0'
 
     GUID = '220fdbee-bea7-4951-9375-f6e76bd981b4'
 


### PR DESCRIPTION
## Examples

In the examples below, the commands are being run in the root directory of a gitlab project and using the implicit `-ProjectId '.'` feature

### Validate the remote pipeline definition (only supports default branch)
```powershell
Test-PipelineDefinition
```
```text
Valid Errors Warnings
----- ------ --------
True  {}     {jobs:build may allow multiple pipelines to run for a single action due to `rules:when` clause with no `workflow:rules` - read more:…
```

### Validate a local file
```powershell
Test-PipelineDefinition -Content ./.gitlab-ci.yml
```
```text
Valid Errors Warnings
----- ------ --------
True  {}     {
```

### Validate arbitrary content

#### Invalid
```powershell
Test-PipelineDefinition -Content @"
>> stages:
>> - build
>> "@ -Select Errors
```
```text
jobs config should contain at least one visible job
```

#### Valid
```powershell
Test-PipelineDefinition -Content @"
>> stages:
>> - build
>>
>> build:
>>   stage: build
>>   script:
>>   - echo 'if you build it, he will come'
>> "@ -Select 'Valid,Errors'
```
```text
Valid Errors
----- ------
 True {}
```

### Get merged yaml
any of the above examples with the addition of `-Select MergedYaml`
