### PR TITLE
Removed token property from response so whole object is returned

### DIFF
--- a/src/GitlabCli/GroupAccessTokens.psm1
+++ b/src/GitlabCli/GroupAccessTokens.psm1
@@ -71,7 +71,7 @@ function New-GitlabGroupAccessToken {
     if ($CopyToClipboard) {
         $Response.token | Set-Clipboard
     } else {
-        $Response.token
+        $Response
     }
 }
 


### PR DESCRIPTION
I need to be able to work with the whole object that is returned when a group access token is created, not just the token itself. For example, I specifically need to be able to grab the `user_id` property in order to then look up that user account.

Removing the `token` property from the currently returned object will see an object similar to the below returned instead of just the token
```
id           : 4703722
name         : testing
revoked      : False
created_at   : 24/05/2022 14:24:37
scopes       : {api}
user_id      : 22574558
expires_at   :
access_level : 30
token        : glpat-B2oe7oGTkzNeBezhWDxs
````