### PR TITLE
Added support for all documented attributes for protecting a repository branch

### DIFF
--- a/src/GitlabCli/Branches.psm1
+++ b/src/GitlabCli/Branches.psm1
@@ -1,3 +1,14 @@
+# https://docs.gitlab.com/ee/api/protected_branches.html
+function Get-GitlabProtectedBranchAccessLevel {
+
+    [PSCustomObject]@{
+        NoAccess = 0
+        Developer = 30
+        Maintainer = 40
+        Admin = 60
+    }
+}
+
 function Get-GitlabBranch {
     [CmdletBinding(DefaultParameterSetName="ByProjectId")]
     param (
@@ -125,17 +136,17 @@ function Protect-GitlabBranch {
         $Name,
 
         [Parameter(Mandatory=$false)]
-        [ValidateSet("0","30","40","60")]
+        [ValidateSet('noaccess','developer','maintainer','admin')]
         [string]
         $PushAccessLevel,
 
         [Parameter(Mandatory=$false)]
-        [ValidateSet("0","30","40","60")]
+        [ValidateSet('noaccess','developer','maintainer','admin')]
         [string]
         $MergeAccessLevel,
 
         [Parameter(Mandatory=$false)]
-        [ValidateSet("0","30","40","60")]
+        [ValidateSet('noaccess','developer','maintainer','admin')]
         [string]
         $UnprotectAccessLevel,
 
@@ -177,9 +188,9 @@ function Protect-GitlabBranch {
         SiteUrl    = $SiteUrl
         Body      = @{
             name = $Branch.Name
-            push_access_level = $PushAccessLevel
-            merge_access_level = $MergeAccessLevel
-            unprotect_access_level = $UnprotectAccessLevel
+            push_access_level = $(Get-GitlabProtectedBranchAccessLevel).$PushAccessLevel
+            merge_access_level = $(Get-GitlabProtectedBranchAccessLevel).$MergeAccessLevel
+            unprotect_access_level = $(Get-GitlabProtectedBranchAccessLevel).$UnprotectAccessLevel
             allow_force_push = $AllowForcePush
             allowed_to_push = $AllowedToPush
             allowed_to_merge = $AllowedToMerge

--- a/src/GitlabCli/Branches.psm1
+++ b/src/GitlabCli/Branches.psm1
@@ -124,9 +124,40 @@ function Protect-GitlabBranch {
         [string]
         $Name,
 
-        [bool]
         [Parameter(Mandatory=$false)]
+        [ValidateSet("0","30","40","60")]
+        [string]
+        $PushAccessLevel,
+
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("0","30","40","60")]
+        [string]
+        $MergeAccessLevel,
+
+        [Parameter(Mandatory=$false)]
+        [ValidateSet("0","30","40","60")]
+        [string]
+        $UnprotectAccessLevel,
+
+        [Parameter(Mandatory=$false)]
+        [bool]
         $AllowForcePush = $false,
+
+        [Parameter(Mandatory=$false)]
+        [array]
+        $AllowedToPush,
+
+        [Parameter(Mandatory=$false)]
+        [array]
+        $AllowedToMerge,
+
+        [Parameter(Mandatory=$false)]
+        [array]
+        $AllowedToUnprotect,
+
+        [Parameter(Mandatory=$false)]
+        [bool]
+        $CodeOwnerApprovalRequired = $false,
 
         [Parameter(Mandatory=$false)]
         [string]
@@ -144,9 +175,16 @@ function Protect-GitlabBranch {
         HttpMethod = 'POST'
         Path       = "projects/$($Project.Id)/protected_branches"
         SiteUrl    = $SiteUrl
-        Query      = @{
+        Body      = @{
             name = $Branch.Name
+            push_access_level = $PushAccessLevel
+            merge_access_level = $MergeAccessLevel
+            unprotect_access_level = $UnprotectAccessLevel
             allow_force_push = $AllowForcePush
+            allowed_to_push = $AllowedToPush
+            allowed_to_merge = $AllowedToMerge
+            allowed_to_unprotect = $AllowedToUnprotect
+            code_owner_approval_required = $CodeOwnerApprovalRequired
         }
     }
 

--- a/src/GitlabCli/GitlabCli.psd1
+++ b/src/GitlabCli/GitlabCli.psd1
@@ -56,6 +56,7 @@
         'Protect-GitlabBranch'
         'UnProtect-GitlabBranch'
         'Remove-GitlabBranch'
+        'Get-GitlabProtectedBranchAccessLevel'
 
         # Configuration
         'Get-GitlabConfiguration'


### PR DESCRIPTION
Example use case:

```
$projectId = "47037290"
$Name = "main"
$PushAccessLevel = "40"
$MergeAccessLevel = "30"
$UnprotectAccessLevel = "30"
$AllowForcePush = $true
$CodeOwnerApprovalRequired = $true

$hash1 = @{
    user_id = 22882083   
}
$hash2 = @{
    user_id = 1264703
}
$hash3 = @{
    user_id = 6204519
}
$AllowedToPush = @($hash1,$hash2)
$AllowedToMerge = @($hash2)
$AllowedToUnprotect = @($hash3)

$protectParams = @{

    ProjectId                 = $projectId
    Name                      = $Name
    PushAccessLevel           = $PushAccessLevel
    MergeAccessLevel          = $MergeAccessLevel
    UnprotectAccessLevel      = $UnprotectAccessLevel
    AllowForcePush            = $AllowForcePush
    CodeOwnerApprovalRequired = $CodeOwnerApprovalRequired
    AllowedToPush             = $AllowedToPush
    AllowedToMerge            = $AllowedToMerge
    AllowedToUnprotect        = $AllowedToUnprotect
}

Protect-GitlabBranch @protectParams
```