### PR TITLE
Added support for setting masked and protected to false for Set-GitlabGroupVariable

### DIFF
--- a/src/GitlabCli/Groups.psm1
+++ b/src/GitlabCli/Groups.psm1
@@ -271,13 +271,13 @@ function Set-GitlabGroupVariable {
         [string]
         $Value,
 
-        [switch]
+        [bool]
         [Parameter(Mandatory=$false)]
-        $Protect,
+        $Protect = $false,
 
-        [switch]
+        [bool]
         [Parameter(Mandatory=$false)]
-        $Mask,
+        $Mask = $false,
 
         [Parameter(Mandatory=$false)]
         [string]

--- a/src/GitlabCli/Groups.psm1
+++ b/src/GitlabCli/Groups.psm1
@@ -297,8 +297,14 @@ function Set-GitlabGroupVariable {
     if ($Protect) {
         $Query['protected'] = 'true'
     }
+    else {
+        $Query['protected'] = 'false'
+    }
     if ($Mask) {
         $Query['masked'] = 'true'
+    }
+    else {
+        $Query['masked'] = 'false'
     }
 
     try {


### PR DESCRIPTION
Added support for setting `masked` and `protected` to `false`. This caters for scenarios where the Group Variable exists and has `masked` or `protected` properties already set to `true` - currently it is not possible to alter either of those properties and set them to `false`.