### PR TITLE
Constrained Recurse command parameter

### DIFF
--- a/src/GitlabCli/Groups.psm1
+++ b/src/GitlabCli/Groups.psm1
@@ -25,7 +25,7 @@ function Get-GitlabGroup {
         [string]
         $ParentGroupId,
 
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory=$false, ParameterSetName='ByParentGroup')]
         [Alias('r')]
         [switch]
         $Recurse,


### PR DESCRIPTION
It was only being use with ParentGroupId only. This was confusing when Recurse wasn't producing any different output.
