### PR TITLE
Add optional project name filters when cloning a group

### DIFF
--- a/src/GitlabCli/GitlabCli.psd1
+++ b/src/GitlabCli/GitlabCli.psd1
@@ -1,11 +1,11 @@
 @{
-    ModuleVersion = '1.86.1'
+    ModuleVersion = '1.87.0'
 
     PrivateData = @{
         PSData = @{
             LicenseUri = 'https://github.com/chris-peterson/pwsh-gitlab/blob/main/LICENSE'
             ProjectUri = 'https://github.com/chris-peterson/pwsh-gitlab'
-            ReleaseNotes = 'tweaks to slack integration settings'
+            ReleaseNotes = 'https://github.com/chris-peterson/pwsh-gitlab/pull/72'
         }
     }
 


### PR DESCRIPTION
Closes #71 

e.g.

```powershell
Clone-GitlabGroup 'mygroup' -ProjectLike 'infrastructure' -ProjectNotLike 'test-util'
```