### PR TITLE
Adding variables support to New-GitlabPipeline

### DIFF
--- a/src/GitlabCli/Pipelines.psm1
+++ b/src/GitlabCli/Pipelines.psm1
@@ -707,6 +707,10 @@ function New-GitlabPipeline {
         $Ref = '.',
 
         [Parameter(Mandatory=$false)]
+        [System.Object[]]
+        $Variables,
+
+        [Parameter(Mandatory=$false)]
         [switch]
         $Wait,
 
@@ -734,10 +738,16 @@ function New-GitlabPipeline {
         $Ref = $Project.DefaultBranch
     }
 
+    $RequestBody = @{'ref' = $Ref}
+
+    if($Variables) {
+        $RequestBody.Add("variables",$Variables)
+    } 
+
     $GitlabApiArguments = @{
         HttpMethod = "POST"
         Path       = "projects/$ProjectId/pipeline"
-        Query      = @{'ref' = $Ref}
+        Body       = $RequestBody
         SiteUrl    = $SiteUrl
     }
 


### PR DESCRIPTION
Added support for passing a set of Variables via an Object[]

Changed the Invoke arguments to use a body to post the request. Query parameters using their variables notation was sporty and just looks wrong to me ;)

Closes #75 

