### PR TITLE
Fix params name and order in Update-GitlabProjectHook cmdlet

### DIFF
--- a/src/GitlabCli/ProjectHooks.psm1
+++ b/src/GitlabCli/ProjectHooks.psm1
@@ -259,7 +259,7 @@ function Update-GitlabProjectHook {
     }
   }
   
-  Invoke-GitlabApi PUT $UpdateRequest $Resource -SiteUrl $SiteUrl -WhatIf:$WhatIf | New-WrapperObject 'Gitlab.ProjectHook'
+  Invoke-GitlabApi PUT $Resource $Request -SiteUrl $SiteUrl -WhatIf:$WhatIf | New-WrapperObject 'Gitlab.ProjectHook'
 }
 
 # https://docs.gitlab.com/ee/api/projects.html#delete-project-hook


### PR DESCRIPTION
### Changes:
- Fixes inexistent parameter name $UpdateRequest in Invoke-GitlabApi
- Fixes parameters' order in Invoke-GitlabApi
### Rationale:
Unable to update project hooks due to error **"Error Invoke-GitlabApi: Cannot bind argument to parameter 'Path' because it is an empty string."**