### PR TITLE
If there are no variables the body need to be either not there or an …

### DIFF
--- a/src/GitlabCli/Jobs.psm1
+++ b/src/GitlabCli/Jobs.psm1
@@ -183,18 +183,17 @@ function Start-GitlabJob {
         Path       = "projects/$($Project.Id)/jobs/$JobId/play"
         SiteUrl    = $SiteUrl
         Body       = @{
-            job_variables_attributes = @{}
+            job_variables_attributes = New-Object -TypeName System.Collections.ArrayList
         }
     }
 
     if ($Variables) {
-        $ReformattedVariables = $Variables.GetEnumerator() | ForEach-Object {
-            @{
+       $Variables.GetEnumerator() | ForEach-Object {
+            $GitlabApiArguments.Body.job_variables_attributes.Add((@{
                 key           = $_.Name
                 value         = $_.Value
-            }
+            }))
         }
-        $GitlabApiArguments.Body.job_variables_attributes = @($ReformattedVariables)
     }
 
     if ($PSCmdlet.ShouldProcess("start job $($Project.PathWithNamespace)", "$($GitlabApiArguments | ConvertTo-Json)")) {


### PR DESCRIPTION
…empty array. I've chosen empty array.

Updated the code the creates the variables body to add to the array vs re-assigning it. Was running into single vs multiple item fun in powershell.

Fixes Issue #83