### PR TITLE
Setting only_allow_merge_if_all_discussions_are_resolved on a project

### DIFF
--- a/src/GitlabCli/Projects.psm1
+++ b/src/GitlabCli/Projects.psm1
@@ -442,6 +442,10 @@ function Update-GitlabProject {
         $BuildsAccessLevel,
 
         [Parameter(Mandatory=$false)]
+        [switch]
+        $OnlyAllowMergeIfAllDiscussionsAreResolved,
+        
+        [Parameter(Mandatory=$false)]
         [string]
         $SiteUrl
     )
@@ -481,7 +485,16 @@ function Update-GitlabProject {
         $Query.builds_access_level = $BuildsAccessLevel
     }
 
-    if ($PSCmdlet.ShouldProcess("$($Project.PathWithNamespace)", "update project ($($Query | ConvertTo-Json))")) {
+    if($PSBoundParameters.ContainsKey("OnlyAllowMergeIfAllDiscussionsAreResolved") -and `
+       $Project.OnlyAllowMergeIfAllDiscussionsAreResolved -ne $OnlyAllowMergeIfAllDiscussionsAreResolved
+      ) {
+        $Query.only_allow_merge_if_all_discussions_are_resolved = $OnlyAllowMergeIfAllDiscussionsAreResolved
+    }
+
+    if($Query.Keys.Count -le 0) {
+        Write-Host "Nothing to update"
+        $Project    
+    } elseif ($PSCmdlet.ShouldProcess("$($Project.PathWithNamespace)", "update project ($($Query | ConvertTo-Json))")) {
         Invoke-GitlabApi PUT "projects/$($Project.Id)" $Query -SiteUrl $SiteUrl |
             New-WrapperObject 'Gitlab.Project'
     }


### PR DESCRIPTION
Need to be able to set this property on a project.

In all instances the current project or the updated project is returned

`-OnlyAllowMergeIfAllDiscussionsAreResolved`
```pwsh
Get-GitlabProject | Update-GitlabProject -OnlyAllowMergeIfAllDiscussionsAreResolved -Whatif
What if: Performing the operation "update project ({
  "only_allow_merge_if_all_discussions_are_resolved": {
    "IsPresent": true
  }
})" on target "notimportant".
```

`-OnlyAllowMergeIfAllDiscussionsAreResolved:$false`
```pwsh
Get-GitlabProject | Update-GitlabProject -OnlyAllowMergeIfAllDiscussionsAreResolved:$false -Whatif
Nothing to update
```

`-OnlyAllowMergeIfAllDiscussionsAreResolved:$true`
```pwsh
Get-GitlabProject | Update-GitlabProject -OnlyAllowMergeIfAllDiscussionsAreResolved:$true Whatif
What if: Performing the operation "update project ({
  "only_allow_merge_if_all_discussions_are_resolved": {
    "IsPresent": true
  }
})" on target "notimportant".
```

No switch specified
```pwsh 
Get-GitlabProject | Update-GitlabProject -Whatif
Nothing to update
```