### PR TITLE
don't want to push from a forks 'main'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,8 @@ jobs:
       url: https://www.powershellgallery.com/packages/GitlabCli
 
   push:
+    if: github.repository == 'chris-peterson/pwsh-gitlab'
+    
     env:
       IMAGE_NAME: gitlab-cli
       IMAGE_VERSION: ${{ github.ref_name }}


### PR DESCRIPTION
This is causing notifications of a failed job. This will keep forks from getting that.