### PR TITLE
Add support for `.` in project paths

### DIFF
--- a/src/GitlabCli/Git.psm1
+++ b/src/GitlabCli/Git.psm1
@@ -30,9 +30,9 @@ function Get-LocalGitContext {
             }
             catch {
                 # git
-                $OriginUrl -match '@(?<Site>.*?)(/|:)(?<Project>[_a-zA-Z0-9/-]+)' | Out-Null
+                $OriginUrl -match '@(?<Site>.*?)(/|:)(?<Project>[\._a-zA-Z0-9/-]+)' | Out-Null
                 $Context.Site = $Matches.Site
-                $Context.Project = $Matches.Project
+                $Context.Project = $Matches.Project -replace '.git$', ''
             }
 
             $Ref = git status | Select-String "^HEAD detached at (?<sha>.{7,40})`|^On branch (?<branch>.*)"

--- a/src/tests/Git.Tests.ps1
+++ b/src/tests/Git.Tests.ps1
@@ -1,0 +1,130 @@
+BeforeAll {
+  Import-Module $PSScriptRoot/../GitlabCli/Git.psm1 -Force
+}
+
+Describe "Get-LocalGitContext" {
+  Context "When the current directory is not a git repository" {
+    BeforeAll {
+      Mock -CommandName Test-Path `
+      -MockWith {
+        return $false
+      } `
+      -ModuleName Git
+    }
+    It "Should return an empty result" {
+      $Result = Get-LocalGitContext
+      $Result.Site | Should -BeNullOrEmpty
+      $Result.Project | Should -BeNullOrEmpty
+      $Result.Branch | Should -BeNullOrEmpty
+    }
+  }
+
+  Context "When the current directory is a git repository" {
+    BeforeAll {
+      Mock -CommandName Test-Path `
+        -MockWith {
+        return $true
+      }`
+      -ModuleName Git
+
+      Mock -CommandName git `
+        -ParameterFilter { 
+          $args -match "status" 
+        } `
+        -MockWith {
+          return "On branch main"
+        } `
+        -ModuleName Git
+    }
+
+    Context "When the remote origin url is an https url" {
+      BeforeAll {
+        Mock `
+          -ModuleName Git `
+          -CommandName git `
+          -ParameterFilter { 
+            $args[0] -eq 'config' -and `
+              $args[1] -eq '--get' -and `
+              $args[2] -eq 'remote.origin.url' 
+          } `
+          -MockWith {
+            return 'https://gitlab.com/group/blah-project-name'  
+          }
+
+          $Result = Get-LocalGitContext
+      }
+
+      It "Should return the site" {
+        $Result.Site | Should -Be "gitlab.com"
+      }
+
+      It "Should return the project" {
+        $Result.Project | Should -Be "group/blah-project-name"
+      }
+
+      It "Should Return the branch" {
+        $Result.Branch | Should -Be "main"
+      } 
+    }
+
+    Context "When the remote origin url is a git url with .git extension" {
+      BeforeAll {
+        Mock `
+          -ModuleName Git `
+          -CommandName git `
+          -ParameterFilter { 
+            $args[0] -eq 'config' -and `
+              $args[1] -eq '--get' -and `
+              $args[2] -eq 'remote.origin.url' 
+          } `
+          -MockWith {
+            return 'git@gitlab.com:group/blah-project-name.git' 
+          }
+
+          $Result = Get-LocalGitContext
+      }
+
+      It "Should return the site" {
+        $Result.Site | Should -Be "gitlab.com"
+      }
+
+      It "Should return the project" {
+        $Result.Project | Should -Be "group/blah-project-name"
+      }
+
+      It "Should return the branch name" {
+        $Result.Branch | Should -Be "main"
+      }
+    }
+    
+    Context "When the remote origin url is a git url with periods in the path and .git extension" {
+      BeforeAll {
+        Mock `
+        -ModuleName Git `
+        -CommandName git `
+        -ParameterFilter { 
+          $args[0] -eq 'config' -and `
+            $args[1] -eq '--get' -and `
+            $args[2] -eq 'remote.origin.url' 
+        } `
+        -MockWith {
+          return 'git@gitlab.com:group/blah.project.name.git' 
+        }
+
+        $Result = Get-LocalGitContext
+      }
+
+      It "Should return the site" {
+        $Result.Site | Should -Be "gitlab.com"
+      }
+
+      It "Should return the project" {
+        $Result.Project | Should -Be "group/blah.project.name"
+      }
+
+      It "Should return the branch name" {
+        $Result.Branch | Should -Be "main"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes #88 

The unit tests were created to vet the regex updates as they can be very fiddly.

Fixed issue with getting 404 when using any GitlabCli commands that interrogate the current folder for git information. Projects can have a `.` in their path and this wasn't accomodated for in the current regex Got mired in not capturing `.git` when it's there. There are two formats for git repo urls that aren't http based. These can have either .git or not on the end when running `git config --get remote.origin.url`

For some reason I wasn't able to figure that part out. Ended up with a best effort just removing .git from the end.

To invoke the tests run `Invoke-Pester -Output Detailed` in the root of the repo, it should find them automatically.

<img width="733" alt="TestRun" src="https://github.com/chris-peterson/pwsh-gitlab/assets/914185/af7ebeb0-244a-4ea7-ae61-e3af780d6614">
