### PR TITLE
Add parameter to new group access token

### DIFF
--- a/src/GitlabCli/GroupAccessTokens.psm1
+++ b/src/GitlabCli/GroupAccessTokens.psm1
@@ -1,6 +1,27 @@
-# https://docs.gitlab.com/ee/api/group_access_tokens.html
 
-# https://docs.gitlab.com/ee/api/group_access_tokens.html#list-group-access-tokens
+<#
+.SYNOPSIS
+Get the groups access tokens
+
+.DESCRIPTION
+When no tokenid is specificed, it will return all of the tokens for the group
+
+.PARAMETER GroupId
+ The ID or URL-encoded path of the group. 
+
+.PARAMETER TokenId
+  The ID of the access token to get details of.
+
+.PARAMETER SiteUrl
+  The URL of the Gitlab instance. If not provided, the default will be used.
+
+.PARAMETER WhatIf
+  If this switch is enabled, the function will not make any changes and will only return the url that would have been called.
+
+.LINK
+ https://docs.gitlab.com/ee/api/group_access_tokens.html
+ https://docs.gitlab.com/ee/api/group_access_tokens.html#list-group-access-tokens
+#>
 function Get-GitlabGroupAccessToken {
     param (
         [Parameter(Position=0, Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
@@ -28,7 +49,41 @@ function Get-GitlabGroupAccessToken {
     Invoke-GitlabApi GET $Resource -SiteUrl $SiteUrl -WhatIf:$WhatIf | New-WrapperObject 'Gitlab.AccessToken'
 }
 
-# https://docs.gitlab.com/ee/api/group_access_tokens.html#create-a-group-access-token
+
+<#
+.SYNOPSIS
+Creates a group access token
+
+.DESCRIPTION
+Create a group access token. You must have the Owner role for the group to create group access tokens.
+
+.PARAMETER GroupId
+The ID or URL-encoded path of the group. 
+
+.PARAMETER Name
+The name of the access token.
+
+.PARAMETER Scope
+The scopes of the access token. Values can be 'api', 'read_api', 'read_registry', 'write_registry', 'read_repository', 'write_repository'
+
+.PARAMETER AccessLevel
+The level of access the token will have. Values can be 'guest' , 'reporter', 'developer', 'maintainer', 'owner'
+Default will be 'maintainer'
+
+.PARAMETER ExpiresAt
+The expiration date for the access token. Default will be 1 year from now. This can't be any longer than 1 year from now. The time component is ignored and only the year month and date are reflected
+
+.PARAMETER CopyToClipboard
+If this switch is enabled, the token will be copied to the clipboard.
+
+.NOTES
+This function is a wrapper around the Gitlab API endpoint POST /groups/:id/access_tokens
+
+.LINK
+https://docs.gitlab.com/ee/api/group_access_tokens.html#create-a-group-access-token
+https://docs.gitlab.com/ee/api/rest/index.html#namespaced-path-encoding
+
+#>
 function New-GitlabGroupAccessToken {
     param (
         [Parameter(Position=0, Mandatory=$true)]
@@ -49,6 +104,11 @@ function New-GitlabGroupAccessToken {
         [ValidateSet('guest', 'reporter', 'developer', 'maintainer', 'owner')]
         $AccessLevel = 'maintainer',
 
+        [Parameter(Mandatory=$false)]
+        [System.DateTime]
+        [ValidateScript({ $_ -le (Get-Date).AddYears(1)},ErrorMessage = "ExpiresAt can't be more than 1 year from now")]
+        $ExpiresAt = $(Get-Date).AddYears(1),
+
         [switch]
         [Parameter(Mandatory=$false)]
         $CopyToClipboard,
@@ -66,6 +126,7 @@ function New-GitlabGroupAccessToken {
         name = $Name
         scopes = $Scope
         access_level = Get-GitlabMemberAccessLevel $AccessLevel
+        expires_at = $ExpiresAt.ToString('yyyy-MM-dd')
     } -SiteUrl $SiteUrl -WhatIf:$WhatIf
 
     if ($CopyToClipboard) {

--- a/src/tests/GroupAccessTokens.Tests.ps1
+++ b/src/tests/GroupAccessTokens.Tests.ps1
@@ -1,0 +1,103 @@
+BeforeAll {
+  Import-Module $PSScriptRoot/../GitlabCli/GroupAccessTokens.psm1 -Force
+}
+
+Describe "Get-GitlabGroupAccessToken" {
+  BeforeEach {
+    Mock -CommandName Invoke-GitlabApi -ModuleName GroupAccessTokens -MockWith { write-host "fallthrough"; throw "Mock fall through, check your parameter filters"}
+  }
+
+  Context "When no group access tokens" {
+    BeforeEach {
+      Mock -CommandName Invoke-GitlabApi `
+        -ParameterFilter { 
+          $Method -eq 'GET' `
+          -and $HttpMethod -eq 'GET' `
+          -and $Whatif -eq $False `
+          -and $Path -eq 'groups/1/access_tokens' 
+        } `
+        -MockWith {
+          return @()
+        } `
+        -ModuleName GroupAccessTokens
+    }
+    It "Should return an empty result" {
+      $Result = Get-GitlabGroupAccessToken -GroupId 1
+      $Result | Should -BeNullOrEmpty
+    }
+  }
+
+  Context "When there are group access tokens" {
+    BeforeEach {
+      Mock -CommandName Invoke-GitlabApi -ModuleName GroupAccessTokens `
+        -ParameterFilter { 
+          $Method -eq 'GET' `
+          -and $HttpMethod -eq 'GET' `
+          -and $Whatif -eq $False `
+          -and $Path -eq 'groups/1/access_tokens' 
+        } `
+        -MockWith {
+          return @(
+            [PSCustomObject]@{
+              id = 1
+              name = "token1"
+              token = "token1"
+              expires_at = (Get-Date).AddMonths(6).ToString('yyyy-MM-dd')
+              scope = "api"
+            },
+            [PSCustomObject]@{
+              id = 2
+              name = "token2"
+              token = "token2"
+              expires_at = (Get-Date).AddMonths(6).ToString('yyyy-MM-dd')
+              scope = "api"
+            }
+          )
+        }
+    }
+    It "Should return the group access tokens" {
+      $Result = Get-GitlabGroupAccessToken -GroupId 1
+      $Result | Should -HaveCount 2
+      $Result[0].Name | Should -Be "token1"
+      $Result[1].Name | Should -Be "token2"
+    }
+  }
+}
+
+Describe "New-GitlabGroupAccessToken" {
+  BeforeEach {
+    Mock -CommandName Invoke-GitlabApi -ModuleName GroupAccessTokens -MockWith { write-host "fallthrough"; throw "Mock fall through, check your parameter filters"}
+  }
+
+  Context "When creating a new group access token" {
+    BeforeEach {
+      Mock -CommandName Invoke-GitlabApi -ModuleName GroupAccessTokens `
+        -ParameterFilter { 
+          $Method -eq 'POST' `
+          -and $HttpMethod -eq 'POST' `
+          -and $Whatif -eq $False `
+          -and $Path -eq 'groups/1/access_tokens' `
+          -and $Body.scopes -eq @("api")
+        } `
+        -MockWith {
+          return [PSCustomObject]@{
+            id = 1
+            name = "token1"
+            token = "token1"
+            expires_at = (Get-Date).AddMonths(6).ToString('yyyy-MM-dd')
+            scopes = @("api")
+          }
+        }
+    }
+
+    It "Should return the new group access token" {
+      $Result = New-GitlabGroupAccessToken -GroupId 1 -Name "token1" -Scope "api"
+      $Result.Name | Should -Be "token1"
+      $Result.Token  | Should -Be "token1"
+    }
+
+    It "Should fail when Expires At is more than a year from now" {
+      { New-GitlabGroupAccessToken -GroupId 1 -Name "token1" -Scope "api" -ExpiresAt (Get-Date).AddYears(2) } | Should -Throw
+    }
+  }
+}


### PR DESCRIPTION
Updates for a new required parameter on the GroupAccessTokens api. Somewhere in the v16 line of things it was made required.