### PR TITLE
feat: ✨ Allow to get all variables of a project or a group

### DIFF
--- a/src/GitlabCli/Groups.psm1
+++ b/src/GitlabCli/Groups.psm1
@@ -247,7 +247,17 @@ function Get-GitlabGroupVariable {
         [Parameter()]
         [string]
         $SiteUrl
+
+        [Parameter()]
+        [uint]
+        $MaxPages,
+
+        [switch]
+        [Parameter()]
+        $All
     )
+
+    $MaxPages = Get-GitlabMaxPages -MaxPages:$MaxPages -All:$All
 
     $GroupId = $GroupId | ConvertTo-UrlEncoded
 
@@ -257,7 +267,7 @@ function Get-GitlabGroupVariable {
     }
     else {
         # https://docs.gitlab.com/ee/api/group_level_variables.html#list-group-variables
-        Invoke-GitlabApi GET "groups/$GroupId/variables" -SiteUrl $SiteUrl | New-WrapperObject 'Gitlab.Variable'
+        Invoke-GitlabApi GET "groups/$GroupId/variables" -SiteUrl $SiteUrl -MaxPages $MaxPages | New-WrapperObject 'Gitlab.Variable'
     }
 }
 

--- a/src/GitlabCli/Projects.psm1
+++ b/src/GitlabCli/Projects.psm1
@@ -583,7 +583,17 @@ function Get-GitlabProjectVariable {
         [Parameter()]
         [string]
         $SiteUrl
+
+        [Parameter()]
+        [uint]
+        $MaxPages,
+
+        [switch]
+        [Parameter()]
+        $All
     )
+
+    $MaxPages = Get-GitlabMaxPages -MaxPages:$MaxPages -All:$All
 
     $Project = Get-GitlabProject $ProjectId
 
@@ -593,7 +603,7 @@ function Get-GitlabProjectVariable {
     }
     else {
         # https://docs.gitlab.com/ee/api/project_level_variables.html#list-project-variables
-        Invoke-GitlabApi GET "projects/$($Project.Id)/variables" -SiteUrl $SiteUrl -WhatIf:$WhatIf | New-WrapperObject 'Gitlab.Variable'
+        Invoke-GitlabApi GET "projects/$($Project.Id)/variables" -SiteUrl $SiteUrl -WhatIf:$WhatIf -MaxPages $MaxPages | New-WrapperObject 'Gitlab.Variable'
     }
 }
 


### PR DESCRIPTION
Hello, the GitLab API limits the retrieval of variables to 20 units by default. This pull request proposes adding `-MaxPages`  option and `-All` switch, to cmdlets for retrieving variables at the Group or Project level. Thank you.