### PR TITLE
Re-enabling Patching of protected branches

### DIFF
--- a/src/GitlabCli/Branches.psm1
+++ b/src/GitlabCli/Branches.psm1
@@ -211,15 +211,15 @@ function Protect-GitlabBranch {
         }
 
         if($MergeAccessLevel) {
-            $Request.merge_access_level = $(Get-GitlabProtectedBranchAccessLevel).$MergeAccessLevel
+            $Request.allowed_to_merge  += @({access_level = $(Get-GitlabProtectedBranchAccessLevel).$MergeAccessLevel})
         }
 
         if($PushAccessLevel) {
-            $Request.push_access_level = $(Get-GitlabProtectedBranchAccessLevel).$PushAccessLevel
+            $Request.allowed_to_push += @({access_level = $(Get-GitlabProtectedBranchAccessLevel).$PushAccessLevel})
         }
 
         if($UnprotectAccessLevel) {
-            $Request.unprotect_access_level = $(Get-GitlabProtectedBranchAccessLevel).$UnprotectAccessLevel
+            $Request.allowed_to_unprotect += @({access_level = $(Get-GitlabProtectedBranchAccessLevel).$UnprotectAccessLevel})
         }
 
         if ($PSCmdlet.ShouldProcess("$($Project.PathWithNamespace) ($Branch)", "update protected branch $($Request | ConvertTo-Json)")) {


### PR DESCRIPTION
Upon checking the issue it has been closed. Performing a test locally it appears that patching now works

Had to build up the patch object the gitlab api complains about the following few things
any of the parameters in the body are null
if patching access levels and that group, user, or access level has already been added, it will error on that too

Here is the issue for reference: https://gitlab.com/gitlab-org/gitlab/-/issues/365520


```pwsh
my-gitlab-project-dir [main] $Project = Get-GitlabProject

my-gitlab-project-dir [main] Get-GitlabProtectedBranch | Format-List

AllowForcePush            : False
CodeOwnerApprovalRequired : False
Id                        : 333333
Inherited                 : False
MergeAccessLevels         : {@{id=12345; access_level=30; access_level_description=Developers + Maintainers; user_id=; group_id=}}
Name                      : main
PushAccessLevels          : {@{id=12345; access_level=40; access_level_description=Maintainers; deploy_key_id=; user_id=; group_id=}}
UnprotectAccessLevels     : {@{id=12345; access_level=60; access_level_description=Instance admins; user_id=; group_id=}}
ProtectedBranchId         : 333333
ProjectId                 : 22222
WhoCanPush                : Maintainers
WhoCanMerge               : Developers + Maintainers

my-gitlab-project-dir [main] Invoke-GitlabApi PATCH "projects/$($Project.Id)/protected_branches/main" -Body @{ allow_force_push='true' } | New-WrapperObject 'Gitlab.ProtectedBranch' | Format-List

AllowForcePush            : True
CodeOwnerApprovalRequired : False
Id                        : 333333
Inherited                 : False
MergeAccessLevels         : {@{id=12345; access_level=30; access_level_description=Developers + Maintainers; user_id=; group_id=}}
Name                      : main
PushAccessLevels          : {@{id=12345; access_level=40; access_level_description=Maintainers; deploy_key_id=; user_id=; group_id=}}
UnprotectAccessLevels     : {@{id=12345; access_level=60; access_level_description=Instance admins; user_id=; group_id=}}
ProtectedBranchId         : 333333
WhoCanPush                : Maintainers
WhoCanMerge               : Developers + Maintainers
```
