### PR TITLE
Wrapping Deploy tokens which is peppered throughout the API surface. …

### DIFF
--- a/src/GitlabCli/DeployKeys.psm1
+++ b/src/GitlabCli/DeployKeys.psm1
@@ -1,0 +1,22 @@
+function Get-GitlabDeployKey {
+  param(
+    [Parameter()]
+    [string]
+    $DeployKeyId,
+
+    [Parameter()]
+    [string]
+    $SiteUrl
+  )
+
+  $GitlabAPIParams = @{
+      Method = 'GET'
+      Path   = "deploy_keys"
+  }
+
+  if($PSBoundParameters.ContainsKey('DeployKeyId')) {
+      $GitlabAPIParams.Path += "/$DeployKeyId"
+  }
+
+  Invoke-GitlabApi @GitlabAPIParams -SiteUrl $SiteUrl -Verbose:$VerbosePreference | New-WrapperObject 'Gitlab.DeployKey'
+}

--- a/src/GitlabCli/GitlabCli.psd1
+++ b/src/GitlabCli/GitlabCli.psd1
@@ -55,6 +55,7 @@
         'Branches.psm1'
         'Commits.psm1'
         'Config.psm1'
+        'DeployKeys.psm1'
         'Deployments.psm1'
         'Environments.psm1'
         'Git.psm1'
@@ -72,6 +73,7 @@
         'Pipelines.psm1'
         'PipelineSchedules.psm1'
         'ProjectAccessTokens.psm1'
+        'ProjectDeployKeys.psm1'
         'Projects.psm1'
         'ProjectHooks.psm1'
         'RepositoryFiles.psm1'
@@ -81,6 +83,7 @@
         'ServiceAccounts.psm1'
         'Todos.psm1'
         'Topics.psm1'
+        'UserDeployKeys.psm1'
         'Users.psm1'
         'Utilities.psm1'
         'Variables.psm1'
@@ -111,6 +114,9 @@
         'Get-DefaultGitlabSite'
         'Set-DefaultGitlabSite'
 
+        # Deploy Keys
+        'Get-GitlabDeployKey'
+
         # GraphQL
         'Invoke-GitlabGraphQL'
 
@@ -139,6 +145,13 @@
         'New-GitlabProjectAccessToken'
         'Remove-GitlabProjectAccessToken'
         'Invoke-GitlabProjectAccessTokenRotation'
+
+        # Project Deploy Keys
+        'Get-GitlabProjectDeployKey'
+        'Add-GitlabProjectDeployKey'
+        'Update-GitlabProjectDeployKey'
+        'Remove-GitlabProjectDeployKey'
+        'Enable-GitlabProjectDeployKey'
 
         # Projects
         'Add-GitlabProjectTopic'
@@ -280,6 +293,9 @@
         'Update-GitlabTopic'
         'Remove-GitlabTopic'
 
+        # User Deploy Keys
+        'Get-GitlabUserDeployKey'
+        
         # User
         'Get-GitlabUser'
         'Get-GitlabCurrentUser'

--- a/src/GitlabCli/ProjectDeployKeys.psm1
+++ b/src/GitlabCli/ProjectDeployKeys.psm1
@@ -1,0 +1,197 @@
+function Get-GitlabProjectDeployKey {
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName,Position=0)]
+        [string]
+        $ProjectId,
+
+        [Parameter()]
+        [string]
+        $DeployKeyId,
+
+        [Parameter()]
+        [string]
+        $SiteUrl
+    ) 
+
+    $Project = Get-GitlabProject -ProjectId $ProjectId -SiteUrl $SiteUrl
+
+    $GitlabAPIParams = @{
+        Method = 'Get'
+        Path   = "projects/$($Project.Id)/deploy_keys"
+    }
+
+    if($PSBoundParameters.ContainsKey('DeployKeyId')) {
+        $GitlabAPIParams.Path += "/$DeployKeyId"
+    }
+
+    Invoke-GitlabApi @GitlabAPIParams -SiteUrl $SiteUrl -Verbose:$VerbosePreference | New-WrapperObject 'Gitlab.DeployKey'
+}
+
+function Add-GitlabProjectDeployKey {
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName,Position=0)]
+        [string]
+        $ProjectId,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Title,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Key,
+
+        [Parameter()]
+        [switch]
+        $CanPush,
+
+        [Parameter()]
+        [string]
+        $SiteUrl
+    ) 
+
+    $Project = Get-GitlabProject -ProjectId $ProjectId -SiteUrl $SiteUrl
+
+    $Body = @{
+        title    = $Title
+        key      = $Key
+        can_push = $CanPush.IsPresent
+    }
+
+    $GitlabAPIParams = @{
+        Method = 'POST'
+        Path   = "projects/$($Project.Id)/deploy_keys"
+        Body   = $Body
+    }
+
+    Invoke-GitlabApi @GitlabAPIParams -SiteUrl $SiteUrl -Verbose:$VerbosePreference -WhatIf:$WhatIfPreference | New-WrapperObject 'Gitlab.DeployKey'
+
+}
+
+function Update-GitlabProjectDeployKey {
+    [CmdletBinding(SupportsShouldProcess,ConfirmImpact='High')]
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName,Position=0)]
+        [string]
+        $ProjectId,
+
+        [Parameter(Mandatory)]
+        [string]
+        $DeployKeyId,
+
+        [Parameter()]
+        [string]
+        $Title,
+
+        [Parameter()]
+        [boolean]
+        $CanPush,
+
+        [Parameter()]
+        [string]
+        $SiteUrl,
+
+        [Parameter()]
+        [switch]
+        $Force
+    ) 
+
+    $Project = Get-GitlabProject -ProjectId $ProjectId -SiteUrl $SiteUrl
+
+    $Body = @{
+    }
+
+    if($PSBoundParameters.ContainsKey('CanPush')) {
+        $Body.can_push = $CanPush
+    }
+
+    $GitlabAPIParams = @{
+        Method = 'PUT'
+        Path   = "projects/$($Project.Id)/deploy_keys/$DeployKeyId"
+        Body   = $Body
+    }
+
+    # https://learn.microsoft.com/en-us/powershell/scripting/learn/deep-dives/everything-about-shouldprocess?view=powershell-7.5#implementing--force
+    if ($Force -and -not $PSBoundParameters.ContainsKey('Confirm')) {
+        $ConfirmPreference = 'None'
+    }
+    
+
+    if($PSCmdlet.ShouldProcess("Update deploy key for project '$($Project.PathWithNamespace)'","Update-GitlabProjectDeployKey")) {
+        Invoke-GitlabApi @GitlabAPIParams -SiteUrl $SiteUrl -Verbose:$VerbosePreference -WhatIf:$WhatIfPreference | New-WrapperObject 'Gitlab.DeployKey'
+    }
+}
+
+function Remove-GitlabProjectDeployKey {
+    [CmdletBinding(SupportsShouldProcess,ConfirmImpact='High')]
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName,Position=0)]
+        [string]
+        $ProjectId,
+
+        [Parameter(Mandatory)]
+        [string]
+        $DeployKeyId,
+
+        [Parameter()]
+        [string]
+        $SiteUrl,
+
+        [Parameter()]
+        [switch]
+        $Force
+    ) 
+
+    $Project = Get-GitlabProject -ProjectId $ProjectId -SiteUrl $SiteUrl
+
+    $GitlabAPIParams = @{
+        Method = 'DELETE'
+        Path   = "projects/$($Project.Id)/deploy_keys/$DeployKeyId"
+    }
+
+    # https://learn.microsoft.com/en-us/powershell/scripting/learn/deep-dives/everything-about-shouldprocess?view=powershell-7.5#implementing--force
+    if ($Force -and -not $PSBoundParameters.ContainsKey('Confirm')) {
+        $ConfirmPreference = 'None'
+    }
+
+    if($PSCmdlet.ShouldProcess("Remove deploy key for project '$($Project.PathWithNamespace)'","Remove-GitlabProjectDeployKey")) {
+        Invoke-GitlabApi @GitlabAPIParams -SiteUrl $SiteUrl -Verbose:$VerbosePreference -WhatIf:$WhatIfPreference | Out-Null
+    }
+}
+
+function Enable-GitlabProjectDeployKey {
+    [CmdletBinding(SupportsShouldProcess,ConfirmImpact='High')]
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName,Position=0)]
+        [string]
+        $ProjectId,
+
+        [Parameter(Mandatory)]
+        [string]
+        $DeployKeyId,
+
+        [Parameter()]
+        [string]
+        $SiteUrl,
+
+        [Parameter()]
+        [switch]
+        $Force
+    ) 
+
+    $Project = Get-GitlabProject -ProjectId $ProjectId -SiteUrl $SiteUrl
+
+    $GitlabAPIParams = @{
+        Method = 'POST'
+        Path   = "projects/$($Project.Id)/deploy_keys/$DeployKeyId/enable"
+    }
+
+    # https://learn.microsoft.com/en-us/powershell/scripting/learn/deep-dives/everything-about-shouldprocess?view=powershell-7.5#implementing--force
+    if ($Force -and -not $PSBoundParameters.ContainsKey('Confirm')) {
+        $ConfirmPreference = 'None'
+    }
+
+    if($PSCmdlet.ShouldProcess("Enable deploy key for project '$($Project.PathWithNamespace)'","Enable-GitlabProjectDeployKey")) {
+        Invoke-GitlabApi @GitlabAPIParams -SiteUrl $SiteUrl -Verbose:$VerbosePreference -WhatIf:$WhatIfPreference | New-WrapperObject 'Gitlab.DeployKey'
+    }
+}

--- a/src/GitlabCli/UserDeployKeys.psm1
+++ b/src/GitlabCli/UserDeployKeys.psm1
@@ -1,0 +1,20 @@
+function Get-GitlabUserDeployKey {
+    param(
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName,Position=0)]
+        [string]
+        $UserId,
+
+        [Parameter()]
+        [string]
+        $SiteUrl
+    ) 
+
+    $User = Get-GitlabUser -UserId $UserId -SiteUrl $SiteUrl
+
+    $GitlabAPIParams = @{
+        Method = 'Get'
+        Path   = "users/$($User.Id)/project_deploy_keys"
+    }
+
+    Invoke-GitlabApi @GitlabAPIParams -SiteUrl $SiteUrl -Verbose:$VerbosePreference | New-WrapperObject 'Gitlab.DeployKey'
+}

--- a/src/GitlabCli/_Init.ps1
+++ b/src/GitlabCli/_Init.ps1
@@ -24,6 +24,7 @@ $global:GitlabIdentityPropertyNameExemptions=@{
     'Gitlab.Branch'                    = ''
     'Gitlab.Commit'                    = 'Id'
     'Gitlab.Configuration'             = ''
+    'Gitlab.DeployKey'                 = 'Id'
     'Gitlab.Environment'               = 'Id'
     'Gitlab.Event'                     = 'Id'
     'Gitlab.Group'                     = 'Id'


### PR DESCRIPTION
…Resulting in User Deploy Keys, Server wide Deploy Keys, and Project Deploy Keys

Protect-GitlabBranch: Build the request body based on the presence of the parameters. GitlabAPI doesn't define behavior of passing empty parameters. Some api's endpoints will error, other just ignore the field"