### PR TITLE
Wrapping /keys api

### DIFF
--- a/src/GitlabCli/GitlabCli.psd1
+++ b/src/GitlabCli/GitlabCli.psd1
@@ -67,6 +67,7 @@
         'Integrations.psm1'
         'Issues.psm1'
         'Jobs.psm1'
+        'Keys.psm1'
         'Members.psm1'
         'MergeRequests.psm1'
         'Milestones.psm1'
@@ -141,6 +142,9 @@
         'Set-GitlabGroupVariable'
         'Update-GitlabGroup'
         'Update-LocalGitlabGroup'
+
+        # SSH Keys
+        'Get-GitlabKey'
 
         # Project Access Tokens
         'Get-GitlabProjectAccessToken'

--- a/src/GitlabCli/Keys.psm1
+++ b/src/GitlabCli/Keys.psm1
@@ -1,0 +1,25 @@
+<#
+.SYNOPSIS
+    Retrieves SSH key by ID or Fingerprint from GitLab.
+
+.LINK
+    https://docs.gitlab.com/api/keys/
+#>
+function Get-GitlabKey {
+    [CmdletBinding(DefaultParameterSetName = 'ById')]
+    param (
+        [Parameter(Mandatory,ParameterSetName = 'ById')]
+        [string]$Id,
+
+        [Parameter(Mandatory,ParameterSetName = 'ByFingerprint')]
+        [string]$Fingerprint
+    )
+
+    $apiParams = @{
+        Method  = 'Get'
+        Path    = if ($Id) { "/keys/$Id" } else { "/keys" }
+        Query   = if ($Fingerprint) { @{ fingerprint = $Fingerprint } } else { $null }
+    }
+
+    Invoke-GitlabApi @apiParams -SiteUrl $SiteUrl | New-WrapperObject 'Gitlab.SSHKey'
+}

--- a/src/GitlabCli/_Init.ps1
+++ b/src/GitlabCli/_Init.ps1
@@ -55,6 +55,7 @@ $global:GitlabIdentityPropertyNameExemptions=@{
     'Gitlab.SearchResult.MergeRequest' = ''
     'Gitlab.SearchResult.Project'      = ''
     'Gitlab.ServiceAccount'            = 'Id'
+    'Gitlab.SSHKey'                    = 'Id'
     'Gitlab.Todo'                      = 'Id'
     'Gitlab.Topic'                     = 'Id'
     'Gitlab.User'                      = 'Id'


### PR DESCRIPTION
Adding wrapper around the keys api. Gitlabs api is a head scratcher sometimes. You must use this api in order to get what user created the key. VS Get-GitlabUserDeployKey which is a cross section of keys that belong to projects that both the user that created the key and the api requester share.

Also not to be confused with /user/keys api which is for getting and adding SSH Keys explicitly.