### PR TITLE
Use Add-Type for custom attribute classes (fixes #156)

### DIFF
--- a/src/GitlabCli/Private/Transformations.ps1
+++ b/src/GitlabCli/Private/Transformations.ps1
@@ -1,70 +1,66 @@
-class TrueOrFalseAttribute : System.Management.Automation.ArgumentTransformationAttribute {
-    [object] Transform([System.Management.Automation.EngineIntrinsics] $engineIntrinsics, $inputData) {
-        if ($inputData -is [bool]) {
-            return $inputData
-        }
-        if ($inputData -eq 'true') {
-            return $true
-        }
-        if ($inputData -eq 'false') {
-            return $false
-        }
-        throw [System.Management.Automation.ArgumentTransformationMetadataException]::new(
-            "Cannot convert '$inputData' to boolean. Use 'true' or 'false'."
-        )
+if (-not ([System.Management.Automation.PSTypeName]'TrueOrFalseAttribute').Type) {
+    Add-Type @'
+using System;
+using System.Management.Automation;
+
+public class TrueOrFalseAttribute : ArgumentTransformationAttribute
+{
+    public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+    {
+        if (inputData is bool) return inputData;
+        string str = inputData?.ToString();
+        if (string.Equals(str, "true", StringComparison.OrdinalIgnoreCase)) return true;
+        if (string.Equals(str, "false", StringComparison.OrdinalIgnoreCase)) return false;
+        throw new ArgumentTransformationMetadataException(
+            string.Format("Cannot convert '{0}' to boolean. Use 'true' or 'false'.", inputData));
     }
 }
 
-class GitlabDateAttribute : System.Management.Automation.ArgumentTransformationAttribute {
-    [object] Transform([System.Management.Automation.EngineIntrinsics] $engineIntrinsics, $inputData) {
-        if ([string]::IsNullOrEmpty($inputData)) {
-            return $inputData
-        }
-
-        if ($inputData -is [datetime]) {
-            return $inputData.ToString('yyyy-MM-dd')
-        }
-
-        if ($inputData -is [string]) {
-            if ($inputData -match '^\d{4}-\d{2}-\d{2}$') {
-                return $inputData
-            }
-
-            $parsedDate = [datetime]::MinValue
-            if ([datetime]::TryParse($inputData, [ref]$parsedDate)) {
-                return $parsedDate.ToString('yyyy-MM-dd')
-            }
-        }
-
-        throw [System.Management.Automation.ArgumentTransformationMetadataException]::new(
-            "Cannot convert '$inputData' to GitLab date format. Provide a DateTime or a parseable date string."
-        )
+public class GitlabDateAttribute : ArgumentTransformationAttribute
+{
+    public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+    {
+        if (inputData == null) return inputData;
+        string str = inputData.ToString();
+        if (string.IsNullOrEmpty(str)) return inputData;
+        if (inputData is DateTime dt) return dt.ToString("yyyy-MM-dd");
+        if (System.Text.RegularExpressions.Regex.IsMatch(str, @"^\d{4}-\d{2}-\d{2}$")) return str;
+        DateTime parsed;
+        if (DateTime.TryParse(str, out parsed)) return parsed.ToString("yyyy-MM-dd");
+        throw new ArgumentTransformationMetadataException(
+            string.Format("Cannot convert '{0}' to GitLab date format. Provide a DateTime or a parseable date string.", inputData));
     }
 }
 
-class AccessLevelAttribute : System.Management.Automation.ArgumentTransformationAttribute {
-    [object] Transform([System.Management.Automation.EngineIntrinsics] $engineIntrinsics, $inputData) {
-        $mapping = @{
-            10 = 'guest'
-            20 = 'reporter'
-            30 = 'developer'
-            40 = 'maintainer'
-            50 = 'owner'
+public class AccessLevelAttribute : ArgumentTransformationAttribute
+{
+    private static readonly System.Collections.Generic.Dictionary<int, string> Mapping =
+        new System.Collections.Generic.Dictionary<int, string>
+        {
+            { 10, "guest" },
+            { 20, "reporter" },
+            { 30, "developer" },
+            { 40, "maintainer" },
+            { 50, "owner" }
+        };
+
+    private static readonly string[] ValidNames = { "guest", "reporter", "developer", "maintainer", "owner" };
+
+    public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+    {
+        string str = inputData?.ToString();
+        foreach (var name in ValidNames)
+        {
+            if (string.Equals(str, name, StringComparison.OrdinalIgnoreCase)) return name;
         }
-
-        $validNames = @('guest', 'reporter', 'developer', 'maintainer', 'owner')
-
-        if ($inputData -in $validNames) {
-            return $inputData
+        int numericValue;
+        if (int.TryParse(str, out numericValue) && Mapping.ContainsKey(numericValue))
+        {
+            return Mapping[numericValue];
         }
-
-        $numericValue = 0
-        if ([int]::TryParse($inputData, [ref]$numericValue) -and $mapping.ContainsKey($numericValue)) {
-            return $mapping[$numericValue]
-        }
-
-        throw [System.Management.Automation.ArgumentTransformationMetadataException]::new(
-            "Cannot convert '$inputData' to access level. Valid values: $($validNames -join ', ') (or numeric: $($mapping.Keys -join ', '))."
-        )
+        throw new ArgumentTransformationMetadataException(
+            string.Format("Cannot convert '{0}' to access level. Valid values: guest, reporter, developer, maintainer, owner (or numeric: 10, 20, 30, 40, 50).", inputData));
     }
+}
+'@
 }

--- a/src/GitlabCli/Private/Validations.ps1
+++ b/src/GitlabCli/Private/Validations.ps1
@@ -1,213 +1,162 @@
-# ============================================================================
-# ValidateSet Generators
-# ============================================================================
-# These classes implement IValidateSetValuesGenerator to provide centralized,
-# reusable ValidateSet values. This eliminates duplication across modules and
-# ensures consistency when the same set of values is used in multiple places.
-#
-# Usage:
-#   [ValidateSet([VisibilityLevel])]
-#   [string] $Visibility
-#
-# Reference:
-#   https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_functions_advanced_parameters#dynamic-validateset-values-using-classes
-# ============================================================================
+if (-not ([System.Management.Automation.PSTypeName]'VisibilityLevel').Type) {
+    Add-Type @'
+using System.Management.Automation;
 
-# ----------------------------------------------------------------------------
-# Visibility Levels
-# ----------------------------------------------------------------------------
-# Used by: Projects, Groups, Snippets
-class VisibilityLevel : System.Management.Automation.IValidateSetValuesGenerator {
-    [string[]] GetValidValues() {
-        return @('private', 'internal', 'public')
-    }
+public class VisibilityLevel : IValidateSetValuesGenerator
+{
+    public string[] GetValidValues() => new[] { "private", "internal", "public" };
 }
 
-# ----------------------------------------------------------------------------
-# Supported Integrations
-# ----------------------------------------------------------------------------
-# Used by: Integrations (multiple functions)
-class SupportedIntegrations : System.Management.Automation.IValidateSetValuesGenerator {
-    [string[]] GetValidValues() {
-        return @('slack', 'gitlab-slack-application')
-    }
+public class SupportedIntegrations : IValidateSetValuesGenerator
+{
+    public string[] GetValidValues() => new[] { "slack", "gitlab-slack-application" };
 }
 
-# ----------------------------------------------------------------------------
-# Slack Notification Events
-# ----------------------------------------------------------------------------
-# Used by: Enable-GitlabProjectSlackNotification
-class SlackNotificationEvent : System.Management.Automation.IValidateSetValuesGenerator {
-    [string[]] GetValidValues() {
-        return @(
-            'alert'
-            'commit'
-            'confidential_issue'
-            'confidential_note'
-            'deployment'
-            'issue'
-            'merge_request'
-            'note'
-            'pipeline'
-            'push'
-            'tag_push'
-            'vulnerability'
-            'wiki_page'
-        )
-    }
+public class SlackNotificationEvent : IValidateSetValuesGenerator
+{
+    public string[] GetValidValues() => new[] {
+        "alert", "commit", "confidential_issue", "confidential_note",
+        "deployment", "issue", "merge_request", "note", "pipeline",
+        "push", "tag_push", "vulnerability", "wiki_page"
+    };
 }
 
-# ----------------------------------------------------------------------------
-# Sort Direction
-# ----------------------------------------------------------------------------
-# Used by: Projects, Releases, Users
-class SortDirection : System.Management.Automation.IValidateSetValuesGenerator {
-    [string[]] GetValidValues() {
-        return @('asc', 'desc')
-    }
+public class SortDirection : IValidateSetValuesGenerator
+{
+    public string[] GetValidValues() => new[] { "asc", "desc" };
 }
 
-# ----------------------------------------------------------------------------
-# Variable Types
-# ----------------------------------------------------------------------------
-# Used by: PipelineSchedules (variables)
-class VariableType : System.Management.Automation.IValidateSetValuesGenerator {
-    [string[]] GetValidValues() {
-        return @('env_var', 'file')
-    }
+public class VariableType : IValidateSetValuesGenerator
+{
+    public string[] GetValidValues() => new[] { "env_var", "file" };
 }
 
-# ----------------------------------------------------------------------------
-# Timezones
-# ----------------------------------------------------------------------------
-# Used by: PipelineSchedules
-# Source: TZInfo::Timezone.all_identifiers
-class GitlabTimezone : System.Management.Automation.IValidateSetValuesGenerator {
-    [string[]] GetValidValues() {
-        return @(
-            "Africa/Abidjan", "Africa/Accra", "Africa/Addis_Ababa", "Africa/Algiers", "Africa/Asmara",
-            "Africa/Asmera", "Africa/Bamako", "Africa/Bangui", "Africa/Banjul", "Africa/Bissau",
-            "Africa/Blantyre", "Africa/Brazzaville", "Africa/Bujumbura", "Africa/Cairo", "Africa/Casablanca",
-            "Africa/Ceuta", "Africa/Conakry", "Africa/Dakar", "Africa/Dar_es_Salaam", "Africa/Djibouti",
-            "Africa/Douala", "Africa/El_Aaiun", "Africa/Freetown", "Africa/Gaborone", "Africa/Harare",
-            "Africa/Johannesburg", "Africa/Juba", "Africa/Kampala", "Africa/Khartoum", "Africa/Kigali",
-            "Africa/Kinshasa", "Africa/Lagos", "Africa/Libreville", "Africa/Lome", "Africa/Luanda",
-            "Africa/Lubumbashi", "Africa/Lusaka", "Africa/Malabo", "Africa/Maputo", "Africa/Maseru",
-            "Africa/Mbabane", "Africa/Mogadishu", "Africa/Monrovia", "Africa/Nairobi", "Africa/Ndjamena",
-            "Africa/Niamey", "Africa/Nouakchott", "Africa/Ouagadougou", "Africa/Porto-Novo", "Africa/Sao_Tome",
-            "Africa/Timbuktu", "Africa/Tripoli", "Africa/Tunis", "Africa/Windhoek",
-            "America/Adak", "America/Anchorage", "America/Anguilla", "America/Antigua", "America/Araguaina",
-            "America/Argentina/Buenos_Aires", "America/Argentina/Catamarca", "America/Argentina/ComodRivadavia",
-            "America/Argentina/Cordoba", "America/Argentina/Jujuy", "America/Argentina/La_Rioja",
-            "America/Argentina/Mendoza", "America/Argentina/Rio_Gallegos", "America/Argentina/Salta",
-            "America/Argentina/San_Juan", "America/Argentina/San_Luis", "America/Argentina/Tucuman",
-            "America/Argentina/Ushuaia", "America/Aruba", "America/Asuncion", "America/Atikokan",
-            "America/Atka", "America/Bahia", "America/Bahia_Banderas", "America/Barbados", "America/Belem",
-            "America/Belize", "America/Blanc-Sablon", "America/Boa_Vista", "America/Bogota", "America/Boise",
-            "America/Buenos_Aires", "America/Cambridge_Bay", "America/Campo_Grande", "America/Cancun",
-            "America/Caracas", "America/Catamarca", "America/Cayenne", "America/Cayman", "America/Chicago",
-            "America/Chihuahua", "America/Ciudad_Juarez", "America/Coral_Harbour", "America/Cordoba",
-            "America/Costa_Rica", "America/Creston", "America/Cuiaba", "America/Curacao", "America/Danmarkshavn",
-            "America/Dawson", "America/Dawson_Creek", "America/Denver", "America/Detroit", "America/Dominica",
-            "America/Edmonton", "America/Eirunepe", "America/El_Salvador", "America/Ensenada",
-            "America/Fort_Nelson", "America/Fort_Wayne", "America/Fortaleza", "America/Glace_Bay",
-            "America/Godthab", "America/Goose_Bay", "America/Grand_Turk", "America/Grenada", "America/Guadeloupe",
-            "America/Guatemala", "America/Guayaquil", "America/Guyana", "America/Halifax", "America/Havana",
-            "America/Hermosillo", "America/Indiana/Indianapolis", "America/Indiana/Knox", "America/Indiana/Marengo",
-            "America/Indiana/Petersburg", "America/Indiana/Tell_City", "America/Indiana/Vevay",
-            "America/Indiana/Vincennes", "America/Indiana/Winamac", "America/Indianapolis", "America/Inuvik",
-            "America/Iqaluit", "America/Jamaica", "America/Jujuy", "America/Juneau", "America/Kentucky/Louisville",
-            "America/Kentucky/Monticello", "America/Knox_IN", "America/Kralendijk", "America/La_Paz",
-            "America/Lima", "America/Los_Angeles", "America/Louisville", "America/Lower_Princes", "America/Maceio",
-            "America/Managua", "America/Manaus", "America/Marigot", "America/Martinique", "America/Matamoros",
-            "America/Mazatlan", "America/Mendoza", "America/Menominee", "America/Merida", "America/Metlakatla",
-            "America/Mexico_City", "America/Miquelon", "America/Moncton", "America/Monterrey", "America/Montevideo",
-            "America/Montreal", "America/Montserrat", "America/Nassau", "America/New_York", "America/Nipigon",
-            "America/Nome", "America/Noronha", "America/North_Dakota/Beulah", "America/North_Dakota/Center",
-            "America/North_Dakota/New_Salem", "America/Nuuk", "America/Ojinaga", "America/Panama",
-            "America/Pangnirtung", "America/Paramaribo", "America/Phoenix", "America/Port-au-Prince",
-            "America/Port_of_Spain", "America/Porto_Acre", "America/Porto_Velho", "America/Puerto_Rico",
-            "America/Punta_Arenas", "America/Rainy_River", "America/Rankin_Inlet", "America/Recife",
-            "America/Regina", "America/Resolute", "America/Rio_Branco", "America/Rosario", "America/Santa_Isabel",
-            "America/Santarem", "America/Santiago", "America/Santo_Domingo", "America/Sao_Paulo",
-            "America/Scoresbysund", "America/Shiprock", "America/Sitka", "America/St_Barthelemy",
-            "America/St_Johns", "America/St_Kitts", "America/St_Lucia", "America/St_Thomas", "America/St_Vincent",
-            "America/Swift_Current", "America/Tegucigalpa", "America/Thule", "America/Thunder_Bay",
-            "America/Tijuana", "America/Toronto", "America/Tortola", "America/Vancouver", "America/Virgin",
-            "America/Whitehorse", "America/Winnipeg", "America/Yakutat", "America/Yellowknife",
-            "Antarctica/Casey", "Antarctica/Davis", "Antarctica/DumontDUrville", "Antarctica/Macquarie",
-            "Antarctica/Mawson", "Antarctica/McMurdo", "Antarctica/Palmer", "Antarctica/Rothera",
-            "Antarctica/South_Pole", "Antarctica/Syowa", "Antarctica/Troll", "Antarctica/Vostok",
-            "Arctic/Longyearbyen",
-            "Asia/Aden", "Asia/Almaty", "Asia/Amman", "Asia/Anadyr", "Asia/Aqtau", "Asia/Aqtobe",
-            "Asia/Ashgabat", "Asia/Ashkhabad", "Asia/Atyrau", "Asia/Baghdad", "Asia/Bahrain", "Asia/Baku",
-            "Asia/Bangkok", "Asia/Barnaul", "Asia/Beirut", "Asia/Bishkek", "Asia/Brunei", "Asia/Calcutta",
-            "Asia/Chita", "Asia/Choibalsan", "Asia/Chongqing", "Asia/Chungking", "Asia/Colombo", "Asia/Dacca",
-            "Asia/Damascus", "Asia/Dhaka", "Asia/Dili", "Asia/Dubai", "Asia/Dushanbe", "Asia/Famagusta",
-            "Asia/Gaza", "Asia/Harbin", "Asia/Hebron", "Asia/Ho_Chi_Minh", "Asia/Hong_Kong", "Asia/Hovd",
-            "Asia/Irkutsk", "Asia/Istanbul", "Asia/Jakarta", "Asia/Jayapura", "Asia/Jerusalem", "Asia/Kabul",
-            "Asia/Kamchatka", "Asia/Karachi", "Asia/Kashgar", "Asia/Kathmandu", "Asia/Katmandu", "Asia/Khandyga",
-            "Asia/Kolkata", "Asia/Krasnoyarsk", "Asia/Kuala_Lumpur", "Asia/Kuching", "Asia/Kuwait", "Asia/Macao",
-            "Asia/Macau", "Asia/Magadan", "Asia/Makassar", "Asia/Manila", "Asia/Muscat", "Asia/Nicosia",
-            "Asia/Novokuznetsk", "Asia/Novosibirsk", "Asia/Omsk", "Asia/Oral", "Asia/Phnom_Penh", "Asia/Pontianak",
-            "Asia/Pyongyang", "Asia/Qatar", "Asia/Qostanay", "Asia/Qyzylorda", "Asia/Rangoon", "Asia/Riyadh",
-            "Asia/Saigon", "Asia/Sakhalin", "Asia/Samarkand", "Asia/Seoul", "Asia/Shanghai", "Asia/Singapore",
-            "Asia/Srednekolymsk", "Asia/Taipei", "Asia/Tashkent", "Asia/Tbilisi", "Asia/Tehran", "Asia/Tel_Aviv",
-            "Asia/Thimbu", "Asia/Thimphu", "Asia/Tokyo", "Asia/Tomsk", "Asia/Ujung_Pandang", "Asia/Ulaanbaatar",
-            "Asia/Ulan_Bator", "Asia/Urumqi", "Asia/Ust-Nera", "Asia/Vientiane", "Asia/Vladivostok",
-            "Asia/Yakutsk", "Asia/Yangon", "Asia/Yekaterinburg", "Asia/Yerevan",
-            "Atlantic/Azores", "Atlantic/Bermuda", "Atlantic/Canary", "Atlantic/Cape_Verde", "Atlantic/Faeroe",
-            "Atlantic/Faroe", "Atlantic/Jan_Mayen", "Atlantic/Madeira", "Atlantic/Reykjavik",
-            "Atlantic/South_Georgia", "Atlantic/St_Helena", "Atlantic/Stanley",
-            "Australia/ACT", "Australia/Adelaide", "Australia/Brisbane", "Australia/Broken_Hill",
-            "Australia/Canberra", "Australia/Currie", "Australia/Darwin", "Australia/Eucla", "Australia/Hobart",
-            "Australia/LHI", "Australia/Lindeman", "Australia/Lord_Howe", "Australia/Melbourne", "Australia/NSW",
-            "Australia/North", "Australia/Perth", "Australia/Queensland", "Australia/South", "Australia/Sydney",
-            "Australia/Tasmania", "Australia/Victoria", "Australia/West", "Australia/Yancowinna",
-            "Brazil/Acre", "Brazil/DeNoronha", "Brazil/East", "Brazil/West",
-            "CET", "CST6CDT", "Canada/Atlantic", "Canada/Central", "Canada/Eastern", "Canada/Mountain",
-            "Canada/Newfoundland", "Canada/Pacific", "Canada/Saskatchewan", "Canada/Yukon",
-            "Chile/Continental", "Chile/EasterIsland", "Cuba",
-            "EET", "EST", "EST5EDT", "Egypt", "Eire",
-            "Etc/GMT", "Etc/GMT+0", "Etc/GMT+1", "Etc/GMT+10", "Etc/GMT+11", "Etc/GMT+12", "Etc/GMT+2",
-            "Etc/GMT+3", "Etc/GMT+4", "Etc/GMT+5", "Etc/GMT+6", "Etc/GMT+7", "Etc/GMT+8", "Etc/GMT+9",
-            "Etc/GMT-0", "Etc/GMT-1", "Etc/GMT-10", "Etc/GMT-11", "Etc/GMT-12", "Etc/GMT-13", "Etc/GMT-14",
-            "Etc/GMT-2", "Etc/GMT-3", "Etc/GMT-4", "Etc/GMT-5", "Etc/GMT-6", "Etc/GMT-7", "Etc/GMT-8",
-            "Etc/GMT-9", "Etc/GMT0", "Etc/Greenwich", "Etc/UCT", "Etc/UTC", "Etc/Universal", "Etc/Zulu",
-            "Europe/Amsterdam", "Europe/Andorra", "Europe/Astrakhan", "Europe/Athens", "Europe/Belfast",
-            "Europe/Belgrade", "Europe/Berlin", "Europe/Bratislava", "Europe/Brussels", "Europe/Bucharest",
-            "Europe/Budapest", "Europe/Busingen", "Europe/Chisinau", "Europe/Copenhagen", "Europe/Dublin",
-            "Europe/Gibraltar", "Europe/Guernsey", "Europe/Helsinki", "Europe/Isle_of_Man", "Europe/Istanbul",
-            "Europe/Jersey", "Europe/Kaliningrad", "Europe/Kiev", "Europe/Kirov", "Europe/Kyiv", "Europe/Lisbon",
-            "Europe/Ljubljana", "Europe/London", "Europe/Luxembourg", "Europe/Madrid", "Europe/Malta",
-            "Europe/Mariehamn", "Europe/Minsk", "Europe/Monaco", "Europe/Moscow", "Europe/Nicosia", "Europe/Oslo",
-            "Europe/Paris", "Europe/Podgorica", "Europe/Prague", "Europe/Riga", "Europe/Rome", "Europe/Samara",
-            "Europe/San_Marino", "Europe/Sarajevo", "Europe/Saratov", "Europe/Simferopol", "Europe/Skopje",
-            "Europe/Sofia", "Europe/Stockholm", "Europe/Tallinn", "Europe/Tirane", "Europe/Tiraspol",
-            "Europe/Ulyanovsk", "Europe/Uzhgorod", "Europe/Vaduz", "Europe/Vatican", "Europe/Vienna",
-            "Europe/Vilnius", "Europe/Volgograd", "Europe/Warsaw", "Europe/Zagreb", "Europe/Zaporozhye",
-            "Europe/Zurich",
-            "Factory", "GB", "GB-Eire", "GMT", "GMT+0", "GMT-0", "GMT0", "Greenwich", "HST", "Hongkong",
-            "Iceland",
-            "Indian/Antananarivo", "Indian/Chagos", "Indian/Christmas", "Indian/Cocos", "Indian/Comoro",
-            "Indian/Kerguelen", "Indian/Mahe", "Indian/Maldives", "Indian/Mauritius", "Indian/Mayotte",
-            "Indian/Reunion",
-            "Iran", "Israel", "Jamaica", "Japan", "Kwajalein", "Libya", "MET", "MST", "MST7MDT",
-            "Mexico/BajaNorte", "Mexico/BajaSur", "Mexico/General", "NZ", "NZ-CHAT", "Navajo", "PRC", "PST8PDT",
-            "Pacific/Apia", "Pacific/Auckland", "Pacific/Bougainville", "Pacific/Chatham", "Pacific/Chuuk",
-            "Pacific/Easter", "Pacific/Efate", "Pacific/Enderbury", "Pacific/Fakaofo", "Pacific/Fiji",
-            "Pacific/Funafuti", "Pacific/Galapagos", "Pacific/Gambier", "Pacific/Guadalcanal", "Pacific/Guam",
-            "Pacific/Honolulu", "Pacific/Johnston", "Pacific/Kanton", "Pacific/Kiritimati", "Pacific/Kosrae",
-            "Pacific/Kwajalein", "Pacific/Majuro", "Pacific/Marquesas", "Pacific/Midway", "Pacific/Nauru",
-            "Pacific/Niue", "Pacific/Norfolk", "Pacific/Noumea", "Pacific/Pago_Pago", "Pacific/Palau",
-            "Pacific/Pitcairn", "Pacific/Pohnpei", "Pacific/Ponape", "Pacific/Port_Moresby", "Pacific/Rarotonga",
-            "Pacific/Saipan", "Pacific/Samoa", "Pacific/Tahiti", "Pacific/Tarawa", "Pacific/Tongatapu",
-            "Pacific/Truk", "Pacific/Wake", "Pacific/Wallis", "Pacific/Yap",
-            "Poland", "Portugal", "ROC", "ROK", "Singapore", "Turkey", "UCT",
-            "US/Alaska", "US/Aleutian", "US/Arizona", "US/Central", "US/East-Indiana", "US/Eastern",
-            "US/Hawaii", "US/Indiana-Starke", "US/Michigan", "US/Mountain", "US/Pacific", "US/Samoa",
-            "UTC", "Universal", "W-SU", "WET", "Zulu"
-        )
-    }
+public class GitlabTimezone : IValidateSetValuesGenerator
+{
+    public string[] GetValidValues() => new[] {
+        "Africa/Abidjan", "Africa/Accra", "Africa/Addis_Ababa", "Africa/Algiers", "Africa/Asmara",
+        "Africa/Asmera", "Africa/Bamako", "Africa/Bangui", "Africa/Banjul", "Africa/Bissau",
+        "Africa/Blantyre", "Africa/Brazzaville", "Africa/Bujumbura", "Africa/Cairo", "Africa/Casablanca",
+        "Africa/Ceuta", "Africa/Conakry", "Africa/Dakar", "Africa/Dar_es_Salaam", "Africa/Djibouti",
+        "Africa/Douala", "Africa/El_Aaiun", "Africa/Freetown", "Africa/Gaborone", "Africa/Harare",
+        "Africa/Johannesburg", "Africa/Juba", "Africa/Kampala", "Africa/Khartoum", "Africa/Kigali",
+        "Africa/Kinshasa", "Africa/Lagos", "Africa/Libreville", "Africa/Lome", "Africa/Luanda",
+        "Africa/Lubumbashi", "Africa/Lusaka", "Africa/Malabo", "Africa/Maputo", "Africa/Maseru",
+        "Africa/Mbabane", "Africa/Mogadishu", "Africa/Monrovia", "Africa/Nairobi", "Africa/Ndjamena",
+        "Africa/Niamey", "Africa/Nouakchott", "Africa/Ouagadougou", "Africa/Porto-Novo", "Africa/Sao_Tome",
+        "Africa/Timbuktu", "Africa/Tripoli", "Africa/Tunis", "Africa/Windhoek",
+        "America/Adak", "America/Anchorage", "America/Anguilla", "America/Antigua", "America/Araguaina",
+        "America/Argentina/Buenos_Aires", "America/Argentina/Catamarca", "America/Argentina/ComodRivadavia",
+        "America/Argentina/Cordoba", "America/Argentina/Jujuy", "America/Argentina/La_Rioja",
+        "America/Argentina/Mendoza", "America/Argentina/Rio_Gallegos", "America/Argentina/Salta",
+        "America/Argentina/San_Juan", "America/Argentina/San_Luis", "America/Argentina/Tucuman",
+        "America/Argentina/Ushuaia", "America/Aruba", "America/Asuncion", "America/Atikokan",
+        "America/Atka", "America/Bahia", "America/Bahia_Banderas", "America/Barbados", "America/Belem",
+        "America/Belize", "America/Blanc-Sablon", "America/Boa_Vista", "America/Bogota", "America/Boise",
+        "America/Buenos_Aires", "America/Cambridge_Bay", "America/Campo_Grande", "America/Cancun",
+        "America/Caracas", "America/Catamarca", "America/Cayenne", "America/Cayman", "America/Chicago",
+        "America/Chihuahua", "America/Ciudad_Juarez", "America/Coral_Harbour", "America/Cordoba",
+        "America/Costa_Rica", "America/Creston", "America/Cuiaba", "America/Curacao", "America/Danmarkshavn",
+        "America/Dawson", "America/Dawson_Creek", "America/Denver", "America/Detroit", "America/Dominica",
+        "America/Edmonton", "America/Eirunepe", "America/El_Salvador", "America/Ensenada",
+        "America/Fort_Nelson", "America/Fort_Wayne", "America/Fortaleza", "America/Glace_Bay",
+        "America/Godthab", "America/Goose_Bay", "America/Grand_Turk", "America/Grenada", "America/Guadeloupe",
+        "America/Guatemala", "America/Guayaquil", "America/Guyana", "America/Halifax", "America/Havana",
+        "America/Hermosillo", "America/Indiana/Indianapolis", "America/Indiana/Knox", "America/Indiana/Marengo",
+        "America/Indiana/Petersburg", "America/Indiana/Tell_City", "America/Indiana/Vevay",
+        "America/Indiana/Vincennes", "America/Indiana/Winamac", "America/Indianapolis", "America/Inuvik",
+        "America/Iqaluit", "America/Jamaica", "America/Jujuy", "America/Juneau", "America/Kentucky/Louisville",
+        "America/Kentucky/Monticello", "America/Knox_IN", "America/Kralendijk", "America/La_Paz",
+        "America/Lima", "America/Los_Angeles", "America/Louisville", "America/Lower_Princes", "America/Maceio",
+        "America/Managua", "America/Manaus", "America/Marigot", "America/Martinique", "America/Matamoros",
+        "America/Mazatlan", "America/Mendoza", "America/Menominee", "America/Merida", "America/Metlakatla",
+        "America/Mexico_City", "America/Miquelon", "America/Moncton", "America/Monterrey", "America/Montevideo",
+        "America/Montreal", "America/Montserrat", "America/Nassau", "America/New_York", "America/Nipigon",
+        "America/Nome", "America/Noronha", "America/North_Dakota/Beulah", "America/North_Dakota/Center",
+        "America/North_Dakota/New_Salem", "America/Nuuk", "America/Ojinaga", "America/Panama",
+        "America/Pangnirtung", "America/Paramaribo", "America/Phoenix", "America/Port-au-Prince",
+        "America/Port_of_Spain", "America/Porto_Acre", "America/Porto_Velho", "America/Puerto_Rico",
+        "America/Punta_Arenas", "America/Rainy_River", "America/Rankin_Inlet", "America/Recife",
+        "America/Regina", "America/Resolute", "America/Rio_Branco", "America/Rosario", "America/Santa_Isabel",
+        "America/Santarem", "America/Santiago", "America/Santo_Domingo", "America/Sao_Paulo",
+        "America/Scoresbysund", "America/Shiprock", "America/Sitka", "America/St_Barthelemy",
+        "America/St_Johns", "America/St_Kitts", "America/St_Lucia", "America/St_Thomas", "America/St_Vincent",
+        "America/Swift_Current", "America/Tegucigalpa", "America/Thule", "America/Thunder_Bay",
+        "America/Tijuana", "America/Toronto", "America/Tortola", "America/Vancouver", "America/Virgin",
+        "America/Whitehorse", "America/Winnipeg", "America/Yakutat", "America/Yellowknife",
+        "Antarctica/Casey", "Antarctica/Davis", "Antarctica/DumontDUrville", "Antarctica/Macquarie",
+        "Antarctica/Mawson", "Antarctica/McMurdo", "Antarctica/Palmer", "Antarctica/Rothera",
+        "Antarctica/South_Pole", "Antarctica/Syowa", "Antarctica/Troll", "Antarctica/Vostok",
+        "Arctic/Longyearbyen",
+        "Asia/Aden", "Asia/Almaty", "Asia/Amman", "Asia/Anadyr", "Asia/Aqtau", "Asia/Aqtobe",
+        "Asia/Ashgabat", "Asia/Ashkhabad", "Asia/Atyrau", "Asia/Baghdad", "Asia/Bahrain", "Asia/Baku",
+        "Asia/Bangkok", "Asia/Barnaul", "Asia/Beirut", "Asia/Bishkek", "Asia/Brunei", "Asia/Calcutta",
+        "Asia/Chita", "Asia/Choibalsan", "Asia/Chongqing", "Asia/Chungking", "Asia/Colombo", "Asia/Dacca",
+        "Asia/Damascus", "Asia/Dhaka", "Asia/Dili", "Asia/Dubai", "Asia/Dushanbe", "Asia/Famagusta",
+        "Asia/Gaza", "Asia/Harbin", "Asia/Hebron", "Asia/Ho_Chi_Minh", "Asia/Hong_Kong", "Asia/Hovd",
+        "Asia/Irkutsk", "Asia/Istanbul", "Asia/Jakarta", "Asia/Jayapura", "Asia/Jerusalem", "Asia/Kabul",
+        "Asia/Kamchatka", "Asia/Karachi", "Asia/Kashgar", "Asia/Kathmandu", "Asia/Katmandu", "Asia/Khandyga",
+        "Asia/Kolkata", "Asia/Krasnoyarsk", "Asia/Kuala_Lumpur", "Asia/Kuching", "Asia/Kuwait", "Asia/Macao",
+        "Asia/Macau", "Asia/Magadan", "Asia/Makassar", "Asia/Manila", "Asia/Muscat", "Asia/Nicosia",
+        "Asia/Novokuznetsk", "Asia/Novosibirsk", "Asia/Omsk", "Asia/Oral", "Asia/Phnom_Penh", "Asia/Pontianak",
+        "Asia/Pyongyang", "Asia/Qatar", "Asia/Qostanay", "Asia/Qyzylorda", "Asia/Rangoon", "Asia/Riyadh",
+        "Asia/Saigon", "Asia/Sakhalin", "Asia/Samarkand", "Asia/Seoul", "Asia/Shanghai", "Asia/Singapore",
+        "Asia/Srednekolymsk", "Asia/Taipei", "Asia/Tashkent", "Asia/Tbilisi", "Asia/Tehran", "Asia/Tel_Aviv",
+        "Asia/Thimbu", "Asia/Thimphu", "Asia/Tokyo", "Asia/Tomsk", "Asia/Ujung_Pandang", "Asia/Ulaanbaatar",
+        "Asia/Ulan_Bator", "Asia/Urumqi", "Asia/Ust-Nera", "Asia/Vientiane", "Asia/Vladivostok",
+        "Asia/Yakutsk", "Asia/Yangon", "Asia/Yekaterinburg", "Asia/Yerevan",
+        "Atlantic/Azores", "Atlantic/Bermuda", "Atlantic/Canary", "Atlantic/Cape_Verde", "Atlantic/Faeroe",
+        "Atlantic/Faroe", "Atlantic/Jan_Mayen", "Atlantic/Madeira", "Atlantic/Reykjavik",
+        "Atlantic/South_Georgia", "Atlantic/St_Helena", "Atlantic/Stanley",
+        "Australia/ACT", "Australia/Adelaide", "Australia/Brisbane", "Australia/Broken_Hill",
+        "Australia/Canberra", "Australia/Currie", "Australia/Darwin", "Australia/Eucla", "Australia/Hobart",
+        "Australia/LHI", "Australia/Lindeman", "Australia/Lord_Howe", "Australia/Melbourne", "Australia/NSW",
+        "Australia/North", "Australia/Perth", "Australia/Queensland", "Australia/South", "Australia/Sydney",
+        "Australia/Tasmania", "Australia/Victoria", "Australia/West", "Australia/Yancowinna",
+        "Brazil/Acre", "Brazil/DeNoronha", "Brazil/East", "Brazil/West",
+        "CET", "CST6CDT", "Canada/Atlantic", "Canada/Central", "Canada/Eastern", "Canada/Mountain",
+        "Canada/Newfoundland", "Canada/Pacific", "Canada/Saskatchewan", "Canada/Yukon",
+        "Chile/Continental", "Chile/EasterIsland", "Cuba",
+        "EET", "EST", "EST5EDT", "Egypt", "Eire",
+        "Etc/GMT", "Etc/GMT+0", "Etc/GMT+1", "Etc/GMT+10", "Etc/GMT+11", "Etc/GMT+12", "Etc/GMT+2",
+        "Etc/GMT+3", "Etc/GMT+4", "Etc/GMT+5", "Etc/GMT+6", "Etc/GMT+7", "Etc/GMT+8", "Etc/GMT+9",
+        "Etc/GMT-0", "Etc/GMT-1", "Etc/GMT-10", "Etc/GMT-11", "Etc/GMT-12", "Etc/GMT-13", "Etc/GMT-14",
+        "Etc/GMT-2", "Etc/GMT-3", "Etc/GMT-4", "Etc/GMT-5", "Etc/GMT-6", "Etc/GMT-7", "Etc/GMT-8",
+        "Etc/GMT-9", "Etc/GMT0", "Etc/Greenwich", "Etc/UCT", "Etc/UTC", "Etc/Universal", "Etc/Zulu",
+        "Europe/Amsterdam", "Europe/Andorra", "Europe/Astrakhan", "Europe/Athens", "Europe/Belfast",
+        "Europe/Belgrade", "Europe/Berlin", "Europe/Bratislava", "Europe/Brussels", "Europe/Bucharest",
+        "Europe/Budapest", "Europe/Busingen", "Europe/Chisinau", "Europe/Copenhagen", "Europe/Dublin",
+        "Europe/Gibraltar", "Europe/Guernsey", "Europe/Helsinki", "Europe/Isle_of_Man", "Europe/Istanbul",
+        "Europe/Jersey", "Europe/Kaliningrad", "Europe/Kiev", "Europe/Kirov", "Europe/Kyiv", "Europe/Lisbon",
+        "Europe/Ljubljana", "Europe/London", "Europe/Luxembourg", "Europe/Madrid", "Europe/Malta",
+        "Europe/Mariehamn", "Europe/Minsk", "Europe/Monaco", "Europe/Moscow", "Europe/Nicosia", "Europe/Oslo",
+        "Europe/Paris", "Europe/Podgorica", "Europe/Prague", "Europe/Riga", "Europe/Rome", "Europe/Samara",
+        "Europe/San_Marino", "Europe/Sarajevo", "Europe/Saratov", "Europe/Simferopol", "Europe/Skopje",
+        "Europe/Sofia", "Europe/Stockholm", "Europe/Tallinn", "Europe/Tirane", "Europe/Tiraspol",
+        "Europe/Ulyanovsk", "Europe/Uzhgorod", "Europe/Vaduz", "Europe/Vatican", "Europe/Vienna",
+        "Europe/Vilnius", "Europe/Volgograd", "Europe/Warsaw", "Europe/Zagreb", "Europe/Zaporozhye",
+        "Europe/Zurich",
+        "Factory", "GB", "GB-Eire", "GMT", "GMT+0", "GMT-0", "GMT0", "Greenwich", "HST", "Hongkong",
+        "Iceland",
+        "Indian/Antananarivo", "Indian/Chagos", "Indian/Christmas", "Indian/Cocos", "Indian/Comoro",
+        "Indian/Kerguelen", "Indian/Mahe", "Indian/Maldives", "Indian/Mauritius", "Indian/Mayotte",
+        "Indian/Reunion",
+        "Iran", "Israel", "Jamaica", "Japan", "Kwajalein", "Libya", "MET", "MST", "MST7MDT",
+        "Mexico/BajaNorte", "Mexico/BajaSur", "Mexico/General", "NZ", "NZ-CHAT", "Navajo", "PRC", "PST8PDT",
+        "Pacific/Apia", "Pacific/Auckland", "Pacific/Bougainville", "Pacific/Chatham", "Pacific/Chuuk",
+        "Pacific/Easter", "Pacific/Efate", "Pacific/Enderbury", "Pacific/Fakaofo", "Pacific/Fiji",
+        "Pacific/Funafuti", "Pacific/Galapagos", "Pacific/Gambier", "Pacific/Guadalcanal", "Pacific/Guam",
+        "Pacific/Honolulu", "Pacific/Johnston", "Pacific/Kanton", "Pacific/Kiritimati", "Pacific/Kosrae",
+        "Pacific/Kwajalein", "Pacific/Majuro", "Pacific/Marquesas", "Pacific/Midway", "Pacific/Nauru",
+        "Pacific/Niue", "Pacific/Norfolk", "Pacific/Noumea", "Pacific/Pago_Pago", "Pacific/Palau",
+        "Pacific/Pitcairn", "Pacific/Pohnpei", "Pacific/Ponape", "Pacific/Port_Moresby", "Pacific/Rarotonga",
+        "Pacific/Saipan", "Pacific/Samoa", "Pacific/Tahiti", "Pacific/Tarawa", "Pacific/Tongatapu",
+        "Pacific/Truk", "Pacific/Wake", "Pacific/Wallis", "Pacific/Yap",
+        "Poland", "Portugal", "ROC", "ROK", "Singapore", "Turkey", "UCT",
+        "US/Alaska", "US/Aleutian", "US/Arizona", "US/Central", "US/East-Indiana", "US/Eastern",
+        "US/Hawaii", "US/Indiana-Starke", "US/Michigan", "US/Mountain", "US/Pacific", "US/Samoa",
+        "UTC", "Universal", "W-SU", "WET", "Zulu"
+    };
 }
-
+'@
+}


### PR DESCRIPTION
PowerShell classes defined via ScriptsToProcess may not be available for attribute resolution in NestedModules on all PS versions. Convert TrueOrFalseAttribute, GitlabDateAttribute, AccessLevelAttribute, and IValidateSetValuesGenerator classes from PowerShell class syntax to C# via Add-Type, which loads types into the .NET AppDomain where they are universally resolvable.