### PR TITLE
Diagnose incomplete env-var configuration in site resolution

### DIFF
--- a/docs/Deployments/Get-GitlabDeployment.md
+++ b/docs/Deployments/Get-GitlabDeployment.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/Deployments/Get-GitlabDeployment
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 02/26/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: Get-GitlabDeployment
 ---
@@ -29,7 +29,7 @@ Get-GitlabDeployment [-ProjectId <string>] [-EnvironmentName <string>] [-Status 
 
 ```
 Get-GitlabDeployment -DeploymentId <string> [-ProjectId <string>] [-Select <string>]
- [-SiteUrl <string>] [<CommonParameters>]
+ [-SiteUrl <string>]
 ```
 
 ## ALIASES

--- a/docs/Environments/Get-GitlabEnvironment.md
+++ b/docs/Environments/Get-GitlabEnvironment.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/Environments/Get-GitlabEnvironment
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 02/26/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: Get-GitlabEnvironment
 ---
@@ -35,7 +35,7 @@ Get-GitlabEnvironment [-ProjectId <string>] [-Name <string>] [-State <string>] [
 
 ```
 Get-GitlabEnvironment -Search <string> [-ProjectId <string>] [-State <string>] [-Enrich]
- [-MaxPages <int>] [-SiteUrl <string>] [<CommonParameters>]
+ [-MaxPages <int>] [-SiteUrl <string>]
 ```
 
 ## ALIASES

--- a/docs/Integrations/Enable-GitlabProjectSlackNotification.md
+++ b/docs/Integrations/Enable-GitlabProjectSlackNotification.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/Integrations/Enable-GitlabProjectSlackNotification
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 02/26/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: Enable-GitlabProjectSlackNotification
 ---
@@ -23,7 +23,7 @@ Enables and configures Slack notifications for a GitLab project.
 Enable-GitlabProjectSlackNotification -Channel <string> [-ProjectId <string>] [-Webhook <string>]
  [-Username <string>] [-BranchesToBeNotified <string>] [-NotifyOnlyBrokenPipelines <bool>]
  [-JobEvents <bool>] [-Enable <string[]>] [-Disable <string[]>] [-Integration <string>]
- [-SiteUrl <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-SiteUrl <string>] [-WhatIf] [-Confirm]
 ```
 
 ### AllEvents
@@ -32,7 +32,6 @@ Enable-GitlabProjectSlackNotification -Channel <string> [-ProjectId <string>] [-
 Enable-GitlabProjectSlackNotification -Channel <string> [-ProjectId <string>] [-Webhook <string>]
  [-Username <string>] [-BranchesToBeNotified <string>] [-NotifyOnlyBrokenPipelines <bool>]
  [-JobEvents <bool>] [-AllEvents] [-Integration <string>] [-SiteUrl <string>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
 ```
 
 ### NoEvents

--- a/docs/Issues/Get-GitlabIssue.md
+++ b/docs/Issues/Get-GitlabIssue.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/Issues/Get-GitlabIssue
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 02/27/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: Get-GitlabIssue
 ---
@@ -41,7 +41,7 @@ Get-GitlabIssue [[-IssueId] <string>] [-GroupId] <string> [-State <string>] [-Cr
 Get-GitlabIssue [[-IssueId] <string>] -Mine [-State <string>] [-CreatedAfter <string>]
  [-CreatedBefore <string>] [-AssigneeUsername <string>] [-AuthorUsername <string>]
  [-Labels <string>] [-OrderBy <string>] [-Sort <string>] [-MaxPages <uint>] [-All]
- [-SiteUrl <string>] [<CommonParameters>]
+ [-SiteUrl <string>]
 ```
 
 ## ALIASES

--- a/docs/Jobs/Get-GitlabJob.md
+++ b/docs/Jobs/Get-GitlabJob.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/Jobs/Get-GitlabJob
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 02/26/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: Get-GitlabJob
 ---
@@ -30,7 +30,6 @@ Get-GitlabJob [-ProjectId <string>] [-Scope <string>] [-Stage <string>] [-Name <
 ```
 Get-GitlabJob -PipelineId <string> [-ProjectId <string>] [-Stage <string>] [-Name <string>]
  [-IncludeRetried] [-IncludeTrace] [-IncludeVariables] [-MaxPages <uint>] [-All] [-SiteUrl <string>]
- [<CommonParameters>]
 ```
 
 ### ById
@@ -38,7 +37,6 @@ Get-GitlabJob -PipelineId <string> [-ProjectId <string>] [-Stage <string>] [-Nam
 ```
 Get-GitlabJob -JobId <string> [-ProjectId <string>] [-Stage <string>] [-Name <string>]
  [-IncludeTrace] [-IncludeVariables] [-MaxPages <uint>] [-All] [-SiteUrl <string>]
- [<CommonParameters>]
 ```
 
 ## ALIASES

--- a/docs/Labels/New-GitlabLabel.md
+++ b/docs/Labels/New-GitlabLabel.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/Labels/New-GitlabLabel
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 03/14/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: New-GitlabLabel
 ---
@@ -21,7 +21,7 @@ Creates a new label in a GitLab project or group.
 
 ```
 New-GitlabLabel -Name <string> -Color <string> [-ProjectId <string>] [-Description <string>]
- [-Priority <int>] [-SiteUrl <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Priority <int>] [-SiteUrl <string>] [-WhatIf] [-Confirm]
 ```
 
 ### ByGroupId

--- a/docs/Labels/Remove-GitlabLabel.md
+++ b/docs/Labels/Remove-GitlabLabel.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/Labels/Remove-GitlabLabel
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 03/14/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: Remove-GitlabLabel
 ---
@@ -21,7 +21,6 @@ Deletes a label from a GitLab project or group.
 
 ```
 Remove-GitlabLabel -LabelId <int> [-ProjectId <string>] [-SiteUrl <string>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
 ```
 
 ### ByGroupId

--- a/docs/Labels/Update-GitlabLabel.md
+++ b/docs/Labels/Update-GitlabLabel.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/Labels/Update-GitlabLabel
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 03/14/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: Update-GitlabLabel
 ---
@@ -22,7 +22,6 @@ Updates an existing label in a GitLab project or group.
 ```
 Update-GitlabLabel -LabelId <int> [-ProjectId <string>] [-NewName <string>] [-Color <string>]
  [-Description <string>] [-Priority <int>] [-SiteUrl <string>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
 ```
 
 ### ByGroupId

--- a/docs/Members/Get-GitlabMembershipSortKey.md
+++ b/docs/Members/Get-GitlabMembershipSortKey.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/Members/Get-GitlabMembershipSortKey
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 01/02/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: Get-GitlabMembershipSortKey
 ---
@@ -20,7 +20,7 @@ Gets the default sort keys used for sorting membership results.
 ### __AllParameterSets
 
 ```
-Get-GitlabMembershipSortKey [<CommonParameters>]
+Get-GitlabMembershipSortKey
 ```
 
 ## ALIASES

--- a/docs/Members/Set-GitlabGroupMember.md
+++ b/docs/Members/Set-GitlabGroupMember.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/Members/Set-GitlabGroupMember
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 02/26/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: Set-GitlabGroupMember
 ---
@@ -21,7 +21,7 @@ Sets or updates a user's membership in a GitLab group.
 
 ```
 Set-GitlabGroupMember [-UserId] <string> [-AccessLevel] <string> -SiteUrl <string>
- [-GroupId <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-GroupId <string>] [-WhatIf] [-Confirm]
 ```
 
 ## ALIASES

--- a/docs/Members/Set-GitlabProjectMember.md
+++ b/docs/Members/Set-GitlabProjectMember.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/Members/Set-GitlabProjectMember
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 02/26/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: Set-GitlabProjectMember
 ---
@@ -21,7 +21,7 @@ Sets or updates a user's membership in a GitLab project.
 
 ```
 Set-GitlabProjectMember [-UserId] <string> [-AccessLevel] <string> -SiteUrl <string>
- [-ProjectId <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-ProjectId <string>] [-WhatIf] [-Confirm]
 ```
 
 ## ALIASES

--- a/docs/Milestones/Remove-GitlabMilestone.md
+++ b/docs/Milestones/Remove-GitlabMilestone.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/Milestones/Remove-GitlabMilestone
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 03/14/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: Remove-GitlabMilestone
 ---
@@ -21,14 +21,14 @@ Deletes a milestone from a GitLab project or group.
 
 ```
 Remove-GitlabMilestone -MilestoneId <int> [-ProjectId <string>] [-SiteUrl <string>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [-Confirm]
 ```
 
 ### ByGroup
 
 ```
 Remove-GitlabMilestone -MilestoneId <int> [-GroupId <string>] [-SiteUrl <string>] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+ [-Confirm]
 ```
 
 ## ALIASES

--- a/docs/Milestones/Update-GitlabMilestone.md
+++ b/docs/Milestones/Update-GitlabMilestone.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/Milestones/Update-GitlabMilestone
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 03/14/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: Update-GitlabMilestone
 ---
@@ -22,7 +22,7 @@ Updates an existing milestone in a GitLab project or group.
 ```
 Update-GitlabMilestone -MilestoneId <int> [-ProjectId <string>] [-Title <string>]
  [-Description <string>] [-DueDate <string>] [-StartDate <string>] [-StateEvent <string>]
- [-SiteUrl <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-SiteUrl <string>] [-WhatIf] [-Confirm]
 ```
 
 ### ByGroup
@@ -30,7 +30,7 @@ Update-GitlabMilestone -MilestoneId <int> [-ProjectId <string>] [-Title <string>
 ```
 Update-GitlabMilestone -MilestoneId <int> [-GroupId <string>] [-Title <string>]
  [-Description <string>] [-DueDate <string>] [-StartDate <string>] [-StateEvent <string>]
- [-SiteUrl <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-SiteUrl <string>] [-WhatIf] [-Confirm]
 ```
 
 ## ALIASES

--- a/docs/PipelineSchedules/Get-GitlabPipelineSchedule.md
+++ b/docs/PipelineSchedules/Get-GitlabPipelineSchedule.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/PipelineSchedules/Get-GitlabPipelineSchedule
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 02/26/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: Get-GitlabPipelineSchedule
 ---
@@ -28,7 +28,6 @@ Get-GitlabPipelineSchedule [-ProjectId <string>] [-Scope <string>] [-IncludeVari
 
 ```
 Get-GitlabPipelineSchedule -PipelineScheduleId <int> [-ProjectId <string>] [-SiteUrl <string>]
- [<CommonParameters>]
 ```
 
 ## ALIASES

--- a/docs/ProjectAccessTokens/New-GitlabProjectAccessToken.md
+++ b/docs/ProjectAccessTokens/New-GitlabProjectAccessToken.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/ProjectAccessTokens/New-GitlabProjectAccessToken
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 01/02/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: New-GitlabProjectAccessToken
 ---
@@ -22,7 +22,7 @@ Creates a new project access token.
 ```
 New-GitlabProjectAccessToken [-ProjectId] <string> -Name <string> -Scopes <string[]>
  [-Description <string>] [-AccessLevel <string>] [-ExpiresAt <datetime>] [-SiteUrl <string>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-WhatIf] [-Confirm]
 ```
 
 ## ALIASES

--- a/docs/RepositoryFiles/New-GitlabRepositoryFile.md
+++ b/docs/RepositoryFiles/New-GitlabRepositoryFile.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/RepositoryFiles/New-GitlabRepositoryFile
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 02/26/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: New-GitlabRepositoryFile
 ---
@@ -22,7 +22,6 @@ Creates a new file in a GitLab repository.
 ```
 New-GitlabRepositoryFile [-FilePath] <string> -Content <string> -CommitMessage <string>
  [-ProjectId <string>] [-Branch <string>] [-SkipCi <bool>] [-SiteUrl <string>] [-WhatIf] [-Confirm]
- [<CommonParameters>]
 ```
 
 ## ALIASES

--- a/docs/RepositoryFiles/Update-GitlabRepositoryFile.md
+++ b/docs/RepositoryFiles/Update-GitlabRepositoryFile.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/RepositoryFiles/Update-GitlabRepositoryFile
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 02/26/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: Update-GitlabRepositoryFile
 ---
@@ -22,7 +22,7 @@ Updates an existing file in a GitLab repository.
 ```
 Update-GitlabRepositoryFile [-FilePath] <string> -Content <string> -CommitMessage <string>
  [-ProjectId <string>] [-Branch <string>] [-SkipCi <bool>] [-SkipEqualityCheck] [-SiteUrl <string>]
- [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-WhatIf] [-Confirm]
 ```
 
 ## ALIASES

--- a/docs/ServiceAccounts/New-GitlabServiceAccount.md
+++ b/docs/ServiceAccounts/New-GitlabServiceAccount.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/ServiceAccounts/New-GitlabServiceAccount
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 01/02/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: New-GitlabServiceAccount
 ---
@@ -28,7 +28,7 @@ New-GitlabServiceAccount [-Name <string>] [-Username <string>] [-Email <string>]
 
 ```
 New-GitlabServiceAccount -GroupId <string> [-Name <string>] [-Username <string>] [-Email <string>]
- [-SiteUrl <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-SiteUrl <string>] [-WhatIf] [-Confirm]
 ```
 
 ## ALIASES

--- a/docs/Snippets/New-GitlabSnippet.md
+++ b/docs/Snippets/New-GitlabSnippet.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/Snippets/New-GitlabSnippet
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 02/26/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: New-GitlabSnippet
 ---
@@ -21,14 +21,14 @@ Creates a new GitLab snippet.
 
 ```
 New-GitlabSnippet [-Title] <string> -FileName <string> -Content <string> [-Description <string>]
- [-Visibility <string>] [-SiteUrl <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Visibility <string>] [-SiteUrl <string>] [-WhatIf] [-Confirm]
 ```
 
 ### MultipleFiles
 
 ```
 New-GitlabSnippet [-Title] <string> -Files <hashtable[]> [-Description <string>]
- [-Visibility <string>] [-SiteUrl <string>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-Visibility <string>] [-SiteUrl <string>] [-WhatIf] [-Confirm]
 ```
 
 ## ALIASES

--- a/docs/Variables/ConvertTo-GitlabVariables.md
+++ b/docs/Variables/ConvertTo-GitlabVariables.md
@@ -4,7 +4,7 @@ external help file: GitlabCli-Help.xml
 HelpUri: https://chris-peterson.github.io/pwsh-gitlab/#/Variables/ConvertTo-GitlabVariables
 Locale: en-US
 Module Name: GitlabCli
-ms.date: 01/02/2026
+ms.date: 07/21/2026
 PlatyPS schema version: 2024-05-01
 title: ConvertTo-GitlabVariables
 ---
@@ -129,6 +129,10 @@ HIDE_ME
 ### System.Collections.Hashtable
 
 Returns a hashtable.
+
+### System.Collections.Hashtable[]
+
+Returns an array of hashtables in GitLab variable format.
 
 ## NOTES
 

--- a/src/GitlabCli/Config.psm1
+++ b/src/GitlabCli/Config.psm1
@@ -22,6 +22,10 @@ function Get-GitlabConfiguration {
         } | New-GitlabObject 'Gitlab.Configuration'
     }
 
+    if (-not [string]::IsNullOrWhiteSpace($env:GITLAB_URL)) {
+        Write-Warning "GitlabCli: `$env:GITLAB_URL is set ('$env:GITLAB_URL') but `$env:GITLAB_ACCESS_TOKEN is not.  Environment-variable configuration requires both; falling back to file-based configuration.  See https://chris-peterson.github.io/pwsh-gitlab/#/Config/"
+    }
+
     Invoke-GitlabConfigMigration
 
     if (-not (Test-Path $global:GitlabConfigurationPath)) {

--- a/src/GitlabCli/Private/Functions/ConfigurationHelpers.ps1
+++ b/src/GitlabCli/Private/Functions/ConfigurationHelpers.ps1
@@ -131,7 +131,11 @@ function Resolve-GitlabSite {
         return $Default
     }
 
-    throw "SiteUrl: Could not resolve GitLab site.  See https://github.com/chris-peterson/pwsh-gitlab#configuration"
+    $Guidance = "See https://chris-peterson.github.io/pwsh-gitlab/#/Config/"
+    if (-not [string]::IsNullOrWhiteSpace($env:GITLAB_URL) -and [string]::IsNullOrWhiteSpace($env:GITLAB_ACCESS_TOKEN)) {
+        $Guidance = "`$env:GITLAB_URL is set ('$env:GITLAB_URL') but `$env:GITLAB_ACCESS_TOKEN is not -- environment-variable configuration requires both.  $Guidance"
+    }
+    throw "SiteUrl: Could not resolve GitLab site.  $Guidance"
 }
 
 function Get-GitlabResourceFromUrl {

--- a/tests/GitlabConfiguration.Tests.ps1
+++ b/tests/GitlabConfiguration.Tests.ps1
@@ -1,0 +1,52 @@
+BeforeAll {
+    Import-Module $PSScriptRoot/../src/GitlabCli -Force
+}
+
+Describe 'Get-GitlabConfiguration environment-variable handling' {
+
+    BeforeAll {
+        $script:RealConfigPath = $global:GitlabConfigurationPath
+        $script:RealHome = $env:HOME
+        $script:RealUrl = $env:GITLAB_URL
+        $script:RealToken = $env:GITLAB_ACCESS_TOKEN
+
+        $script:TestTempDir = Join-Path ([System.IO.Path]::GetTempPath()) "GitlabCliCfg_$([System.Guid]::NewGuid().ToString('N'))"
+        New-Item -Type Directory $script:TestTempDir -Force | Out-Null
+    }
+
+    AfterAll {
+        $global:GitlabConfigurationPath = $script:RealConfigPath
+        $env:HOME = $script:RealHome
+        if ($null -ne $script:RealUrl) { $env:GITLAB_URL = $script:RealUrl } else { Remove-Item Env:\GITLAB_URL -ErrorAction SilentlyContinue }
+        if ($null -ne $script:RealToken) { $env:GITLAB_ACCESS_TOKEN = $script:RealToken } else { Remove-Item Env:\GITLAB_ACCESS_TOKEN -ErrorAction SilentlyContinue }
+        if (Test-Path $script:TestTempDir) {
+            [System.IO.Directory]::Delete($script:TestTempDir, $true)
+        }
+    }
+
+    BeforeEach {
+        $env:HOME = $script:TestTempDir
+        $global:GitlabConfigurationPath = Join-Path $script:TestTempDir ".config/powershell/gitlabcli/config.yml"
+        Remove-Item $global:GitlabConfigurationPath -Force -ErrorAction SilentlyContinue
+        Remove-Item Env:\GITLAB_URL -ErrorAction SilentlyContinue
+        Remove-Item Env:\GITLAB_ACCESS_TOKEN -ErrorAction SilentlyContinue
+    }
+
+    Context 'When GITLAB_URL is set but GITLAB_ACCESS_TOKEN is not' {
+        BeforeEach {
+            $env:GITLAB_URL = 'gitlab.getty.cloud'
+        }
+
+        It 'warns that the environment-variable configuration is incomplete' {
+            Get-GitlabConfiguration -WarningVariable warnings -WarningAction SilentlyContinue | Out-Null
+            ($warnings -join "`n") | Should -Match 'GITLAB_ACCESS_TOKEN'
+        }
+    }
+
+    Context 'When neither env var is set' {
+        It 'does not warn about incomplete environment-variable configuration' {
+            Get-GitlabConfiguration -WarningVariable warnings -WarningAction SilentlyContinue | Out-Null
+            ($warnings -join "`n") | Should -Not -Match 'GITLAB_ACCESS_TOKEN'
+        }
+    }
+}

--- a/tests/Resolve-GitlabSite.Tests.ps1
+++ b/tests/Resolve-GitlabSite.Tests.ps1
@@ -130,6 +130,37 @@ Describe "Resolve-GitlabSite" {
       }
     }
 
+    Context "When env-var config is incomplete (GITLAB_URL set without access token)" {
+      BeforeEach {
+        $script:SavedUrl = $env:GITLAB_URL
+        $script:SavedToken = $env:GITLAB_ACCESS_TOKEN
+        $env:GITLAB_URL = "gitlab.getty.cloud"
+        Remove-Item Env:\GITLAB_ACCESS_TOKEN -ErrorAction SilentlyContinue
+
+        Mock -CommandName Get-GitlabConfiguration -ModuleName $TestModuleName -MockWith {
+          return [PSCustomObject]@{
+            Sites = @()
+          }
+        }
+        Mock -CommandName Get-LocalGitContext -ModuleName $TestModuleName -MockWith {
+          return $null
+        }
+      }
+
+      AfterEach {
+        if ($null -ne $script:SavedUrl) { $env:GITLAB_URL = $script:SavedUrl } else { Remove-Item Env:\GITLAB_URL -ErrorAction SilentlyContinue }
+        if ($null -ne $script:SavedToken) { $env:GITLAB_ACCESS_TOKEN = $script:SavedToken } else { Remove-Item Env:\GITLAB_ACCESS_TOKEN -ErrorAction SilentlyContinue }
+      }
+
+      It "Should name the missing GITLAB_ACCESS_TOKEN in the error" {
+        { Resolve-GitlabSite } | Should -Throw "*GITLAB_ACCESS_TOKEN*"
+      }
+
+      It "Should point at the current docs, not the dead github anchor" {
+        { Resolve-GitlabSite } | Should -Throw "*chris-peterson.github.io*"
+      }
+    }
+
     Context "When local git context is empty" {
       BeforeEach {
         Mock -CommandName Get-GitlabConfiguration -ModuleName $TestModuleName -MockWith {


### PR DESCRIPTION
## Context

`pwsh-gitlab` figures out which GitLab instance to talk to from one of two config sources: environment variables (`$env:GITLAB_ACCESS_TOKEN`, optionally `$env:GITLAB_URL`) or a sites file managed by `Add-GitlabSite`. Env-var mode activates **solely** on `$env:GITLAB_ACCESS_TOKEN` — `$env:GITLAB_URL` is optional and defaults to `gitlab.com`.

Setting up on a new machine, a user copied only `$env:GITLAB_URL='gitlab.getty.cloud'` into their profile — not the token. Since the token is the sole activation signal, env-var mode never engaged: the module fell through to an empty sites file and `Resolve-GitlabSite` threw a generic `Could not resolve GitLab site`, pointing at a `#configuration` doc anchor that no longer exists. Nothing told them they were one variable short.

This adds signal for that half-configured state without changing how config is resolved.

## Review guide

- **[`Get-GitlabConfiguration` warning](https://github.com/chris-peterson/pwsh-gitlab/pull/159/changes#diff-3823bd35216748e69bca14c389b7d0f25028ee9a444716b5b6f23d4257f88957R25)** — when `$env:GITLAB_URL` is set without the token, warn on the first command (names the missing var, points at current docs) before falling back to the sites file.
- **[`Resolve-GitlabSite` error](https://github.com/chris-peterson/pwsh-gitlab/pull/159/changes#diff-2d97594bb93941cbe14bb4e2037a5e3c8be845806d64cfa3db6b35f90d7ba68aR134)** — the unresolved-site `throw` now names the missing `$env:GITLAB_ACCESS_TOKEN` when that half-configured state is detected, and its link points at the live docs instead of the dead `#configuration` anchor.
- **Tests** — [`GitlabConfiguration.Tests.ps1`](https://github.com/chris-peterson/pwsh-gitlab/pull/159/changes#diff-93304e52049b604e7f7ce056c17ca85b0c2c71af436a49e4f41b2c6ef565f088) covers the warning and its absence; a [new `Resolve-GitlabSite` context](https://github.com/chris-peterson/pwsh-gitlab/pull/159/changes#diff-8b56f656ac591e8e387bd70a191abfabcd475f787f1beba3c155cedf4fc01c5aR133) covers the actionable error. Reproduced end-to-end against the reported scenario; token-only (→ `gitlab.com`) and token+URL setups are unchanged (0 spurious warnings).

## Approach & trade-offs

Warn-and-proceed, not stop — only the genuinely-unresolvable case still hard-stops (now with an actionable message). Stopping on any env-var/file overlap would break users who keep a leftover sites file and set a token in CI.

Deliberately left out: warning when a token **is** set but a sites file also exists (env vars silently shadowing the file). That path works correctly today, and warning there would fire on every command for CI users who legitimately have both. Easy to add if the shadowing turns out worth surfacing.
