### PR TITLE
Add release-driven publish pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches: [ '*' ]
   pull_request:
+  release:
+    types: [ published ]
   workflow_dispatch:
     inputs:
-      force_publish_module:
-        description: 'Force publish module (bypass change detection)'
-        type: boolean
-        default: false
       force_publish_docs:
         description: 'Force publish docs (bypass change detection)'
         type: boolean
@@ -90,7 +88,7 @@ jobs:
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
           Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
-          $Results = Invoke-ScriptAnalyzer -Path ./src -Recurse -Settings ./PSScriptAnalyzerSettings.ps1 -ReportSummary
+          $Results = './src', './build' | Invoke-ScriptAnalyzer -Recurse -Settings ./PSScriptAnalyzerSettings.ps1 -ReportSummary
           
           $Errors = $Results | Where-Object Severity -eq 'Error'
           $Warnings = $Results | Where-Object Severity -eq 'Warning'
@@ -182,14 +180,13 @@ jobs:
             throw $_.Exception.Message
           }
 
-  release-gate:
-    name: Release Gate
+  docs-gate:
+    name: Docs Gate
     needs: [test, security, docs]
     if: github.event.repository.fork == false && github.ref_name == 'main'
     runs-on: ubuntu-latest
     outputs:
       changes_in_docs: ${{ steps.changes.outputs.docs }}
-      changes_in_src: ${{ steps.changes.outputs.src }}
     steps:
       - uses: actions/checkout@v6
       - name: Detect changes
@@ -199,27 +196,45 @@ jobs:
           filters: |
             docs:
               - 'docs/**'
-            src:
-              - 'src/**'
-      - run: echo "All checks passed, proceeding with deployment"
 
-  publish-module:
-    name: Publish Module
-    needs: release-gate
-    if: needs.release-gate.outputs.changes_in_src == 'true' || inputs.force_publish_module == true
+  release:
+    name: Release
+    needs: [test, security, docs]
+    if: github.event.repository.fork == false && github.event_name == 'release'
     runs-on: ubuntu-latest
+
+    permissions:
+      artifact-metadata: write
+      attestations: write
+      contents: write
+      id-token: write
+      packages: write
+
     environment:
       name: PowerShell Gallery
       url: https://www.powershellgallery.com/packages/GitlabCli
 
+    env:
+      IMAGE_ID: ghcr.io/${{ github.repository }}/gitlab-cli
+      VERSION: ${{ github.event.release.tag_name }}
+
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install PlatyPS
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
           Install-Module -Name Microsoft.PowerShell.PlatyPS -Force -Scope CurrentUser
+
+      - name: Plumb version and release notes into the manifest and changelog
+        shell: pwsh
+        env:
+          RELEASE_NOTES: ${{ github.event.release.body }}
+        run: ./build/Update-ReleaseArtifacts.ps1 -Version $env:VERSION -ReleaseNotes $env:RELEASE_NOTES
 
       - name: Export MAML help
         shell: pwsh
@@ -230,33 +245,13 @@ jobs:
         with:
           ApiKey: ${{ secrets.PSGALLERY_API_KEY }}
 
-  publish-docker:
-    name: Publish Docker Image
-    needs: release-gate
-    runs-on: ubuntu-latest
-
-    env:
-      IMAGE_NAME: gitlab-cli
-      REGISTRY: ghcr.io
-      IMAGE_ID: ghcr.io/${{ github.repository }}/gitlab-cli
-
-    permissions:
-      artifact-metadata: write
-      attestations: write
-      contents: read
-      id-token: write
-      packages: write
-
-    steps:
-      - uses: actions/checkout@v6
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
       - name: Log into registry
         uses: docker/login-action@v4
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -266,9 +261,8 @@ jobs:
         with:
           images: ${{ env.IMAGE_ID }}
           tags: |
-            type=ref,event=branch
-            type=sha,prefix={{branch}}-
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=raw,value=latest
 
       - name: Build and push Docker image
         id: build
@@ -286,10 +280,24 @@ jobs:
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
 
+      # Last, so a failed publish leaves main without a commit claiming a
+      # release that never shipped.
+      - name: Commit version bump and changelog to main
+        run: |
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add src/GitlabCli/GitlabCli.psd1 CHANGELOG.md
+          if git diff --cached --quiet; then
+            echo "No manifest or changelog changes to commit"
+          else
+            git commit -m "Release ${VERSION}"
+            git push origin main
+          fi
+
   publish-docs:
     name: Publish Documentation
-    needs: release-gate
-    if: needs.release-gate.outputs.changes_in_docs == 'true' || inputs.force_publish_docs == true
+    needs: docs-gate
+    if: needs.docs-gate.outputs.changes_in_docs == 'true' || inputs.force_publish_docs == true
     runs-on: ubuntu-latest
     permissions:
       pages: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to GitlabCli are recorded here, newest first.
+
+## [1.172.2] - 2026-06-29
+
+### Bug Fixes
+- https://github.com/chris-peterson/pwsh-gitlab/pull/158 - Thanks @rnebular

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,31 @@ just lint-verbose   # Show detailed results
 
 Configuration is in `PSScriptAnalyzerSettings.ps1`.
 
+## Releasing
+
+Releases are driven by [GitHub Releases](https://github.com/chris-peterson/pwsh-gitlab/releases). Publishing a release is the trigger; the release object carries the version and the notes:
+
+- The **tag** is the version, `v`-prefixed (e.g. `v1.173.0`). CI strips the `v` for both `ModuleVersion` and the image tag, so both read `1.173.0`.
+- The **release body** becomes the release notes.
+
+On publish, the `release` job:
+
+1. Writes the version into `GitlabCli.psd1` `ModuleVersion` and the body into `ReleaseNotes`, and prepends a dated section to `CHANGELOG.md`.
+2. Publishes the module to the PowerShell Gallery and the image to GHCR, tagged with the version and `latest`.
+3. Commits the manifest and changelog back to `main`.
+
+The commit-back runs last so that a failed publish leaves `main` without a commit claiming a release that never shipped.
+
+To preview the manifest and changelog edits a release will make, run the script locally with `-WhatIf`:
+
+```powershell
+./build/Update-ReleaseArtifacts.ps1 -Version v1.173.0 -ReleaseNotes "### Bug Fixes`n- ..." -WhatIf
+```
+
+Cut releases from a tag at `main`'s HEAD. The test, security, and docs gates run against the tag, but the `release` job checks out `main` (it has to, to commit the version bump back), so a tag behind `main` publishes `main`'s code rather than the code the gates checked.
+
+The commit-back uses the built-in `GITHUB_TOKEN`. If `main` becomes a protected branch, that token needs permission to push to it.
+
 ## Making Changes
 
 1. Fork the repository

--- a/build/Update-ReleaseArtifacts.ps1
+++ b/build/Update-ReleaseArtifacts.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+    Plumbs a release version and notes into the module manifest and CHANGELOG.
+
+.DESCRIPTION
+    Given a version and release notes (typically from a published GitHub
+    Release), sets ModuleVersion and ReleaseNotes in GitlabCli.psd1 and prepends
+    a dated section to CHANGELOG.md. Run by the release workflow before
+    publishing, and locally to preview the changes a release will make.
+
+.EXAMPLE
+    ./build/Update-ReleaseArtifacts.ps1 -Version v1.173.0 -ReleaseNotes "### Features`n- Added X"
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    # The release version, with or without a leading 'v' (e.g. v1.173.0 or 1.173.0).
+    [Parameter(Mandatory)]
+    [string]
+    $Version,
+
+    [Parameter(Mandatory)]
+    [string]
+    $ReleaseNotes,
+
+    [string]
+    $Date = (Get-Date -Format 'yyyy-MM-dd'),
+
+    [string]
+    $ManifestPath = (Join-Path $PSScriptRoot '../src/GitlabCli/GitlabCli.psd1'),
+
+    [string]
+    $ChangelogPath = (Join-Path $PSScriptRoot '../CHANGELOG.md')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$NormalizedVersion = $Version -replace '^v', ''
+if ($NormalizedVersion -notmatch '^\d+\.\d+\.\d+$') {
+    throw "Version '$Version' is not a three-part version (e.g. v1.173.0)."
+}
+
+$Notes = $ReleaseNotes.Trim()
+if (-not $Notes) {
+    throw 'ReleaseNotes is empty; a release must carry notes.'
+}
+
+# --- Manifest: ModuleVersion + ReleaseNotes ---
+$Manifest = Get-Content $ManifestPath -Raw
+
+$Manifest = [regex]::Replace(
+    $Manifest,
+    "(?m)^(?<pre>\s*ModuleVersion\s*=\s*')[^']*(?<post>')",
+    { param($m) "$($m.Groups['pre'].Value)$NormalizedVersion$($m.Groups['post'].Value)" })
+
+# ReleaseNotes is a single-quoted here-string; swap only its body so the notes
+# are stored verbatim (a MatchEvaluator avoids $-substitution inside the notes).
+$ReleaseNotesPattern = "(?s)(?<open>ReleaseNotes\s*=\s*@'\r?\n).*?(?<close>\r?\n'@)"
+if ($Manifest -notmatch $ReleaseNotesPattern) {
+    throw "Could not find a ReleaseNotes here-string in $ManifestPath."
+}
+$Manifest = [regex]::Replace(
+    $Manifest,
+    $ReleaseNotesPattern,
+    { param($m) "$($m.Groups['open'].Value)$Notes$($m.Groups['close'].Value)" })
+
+if ($PSCmdlet.ShouldProcess($ManifestPath, "set ModuleVersion to $NormalizedVersion and replace ReleaseNotes")) {
+    [System.IO.File]::WriteAllText($ManifestPath, $Manifest)
+
+    # Fail loudly if the edit produced a manifest PowerShell can't parse.
+    $Parsed = Import-PowerShellDataFile -Path $ManifestPath
+    if ($Parsed.ModuleVersion -ne $NormalizedVersion) {
+        throw "Manifest ModuleVersion is '$($Parsed.ModuleVersion)', expected '$NormalizedVersion'."
+    }
+}
+
+# --- CHANGELOG: prepend a dated section ---
+$Header = @"
+# Changelog
+
+All notable changes to GitlabCli are recorded here, newest first.
+"@
+
+$Entry = "## [$NormalizedVersion] - $Date`n`n$Notes"
+
+if (Test-Path $ChangelogPath) {
+    $Existing = (Get-Content $ChangelogPath -Raw).TrimEnd()
+    $FirstEntry = $Existing.IndexOf('## [')
+    if ($FirstEntry -ge 0) {
+        $Intro = $Existing.Substring(0, $FirstEntry).TrimEnd()
+        $Rest = $Existing.Substring($FirstEntry).TrimEnd()
+        $Changelog = "$Intro`n`n$Entry`n`n$Rest"
+    } else {
+        $Changelog = "$Existing`n`n$Entry"
+    }
+} else {
+    $Changelog = "$Header`n`n$Entry"
+}
+
+if ($PSCmdlet.ShouldProcess($ChangelogPath, "prepend a $NormalizedVersion entry dated $Date")) {
+    [System.IO.File]::WriteAllText($ChangelogPath, "$Changelog`n")
+}
+
+if (-not $WhatIfPreference) {
+    Write-Host "Set ModuleVersion to $NormalizedVersion and recorded CHANGELOG entry for $Date." -ForegroundColor Green
+}

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ test:
 
 lint:
     #!/usr/bin/env pwsh
-    $Results = Invoke-ScriptAnalyzer -Path ./src -Recurse -Settings ./PSScriptAnalyzerSettings.ps1
+    $Results = './src', './build' | Invoke-ScriptAnalyzer -Recurse -Settings ./PSScriptAnalyzerSettings.ps1
     if ($Results) { $Results | Format-Table -AutoSize; exit 1 } else { Write-Host "No linting issues found." }
 
 help: help-update help-export

--- a/tests/Update-ReleaseArtifacts.Tests.ps1
+++ b/tests/Update-ReleaseArtifacts.Tests.ps1
@@ -1,0 +1,132 @@
+BeforeAll {
+    $Script = "$PSScriptRoot/../build/Update-ReleaseArtifacts.ps1"
+
+    function New-Fixtures {
+        $Dir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+        New-Item -ItemType Directory -Path $Dir | Out-Null
+
+        $Manifest = @"
+@{
+    ModuleVersion = '1.172.2'
+
+    PrivateData = @{
+        PSData = @{
+            ReleaseNotes =
+@'
+### Bug Fixes
+- https://github.com/chris-peterson/pwsh-gitlab/pull/158 - Thanks @rnebular
+'@
+        }
+    }
+
+    GUID = '220fdbee-bea7-4951-9375-f6e76bd981b4'
+}
+"@
+        $ManifestPath = Join-Path $Dir 'GitlabCli.psd1'
+        [System.IO.File]::WriteAllText($ManifestPath, $Manifest)
+
+        $ChangelogPath = Join-Path $Dir 'CHANGELOG.md'
+        [System.IO.File]::WriteAllText($ChangelogPath, @"
+# Changelog
+
+All notable changes to GitlabCli are recorded here, newest first.
+
+## [1.172.2] - 2026-06-29
+
+### Bug Fixes
+- https://github.com/chris-peterson/pwsh-gitlab/pull/158 - Thanks @rnebular
+"@)
+
+        [pscustomobject]@{
+            Dir           = $Dir
+            ManifestPath  = $ManifestPath
+            ChangelogPath = $ChangelogPath
+        }
+    }
+
+    function Remove-Fixtures($Fixtures) {
+        [System.IO.Directory]::Delete($Fixtures.Dir, $true)
+    }
+}
+
+Describe 'Update-ReleaseArtifacts' {
+
+    Context 'Manifest updates' {
+        BeforeEach { $Fixtures = New-Fixtures }
+        AfterEach { Remove-Fixtures $Fixtures }
+
+        It 'Sets ModuleVersion, stripping a leading v' {
+            & $Script -Version 'v1.173.0' -ReleaseNotes "### Features`n- Added X" `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21'
+            (Import-PowerShellDataFile -Path $Fixtures.ManifestPath).ModuleVersion | Should -Be '1.173.0'
+        }
+
+        It 'Replaces the ReleaseNotes body verbatim, including literal dollar signs' {
+            & $Script -Version '1.173.0' -ReleaseNotes "### Features`n- Added `$special" `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21'
+            $Notes = (Import-PowerShellDataFile -Path $Fixtures.ManifestPath).PrivateData.PSData.ReleaseNotes
+            $Notes | Should -BeLike '*Added $special*'
+            $Notes | Should -Not -BeLike '*rnebular*'
+        }
+
+        It 'Leaves a manifest PowerShell can still parse' {
+            & $Script -Version '1.173.0' -ReleaseNotes 'notes' `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21'
+            (Import-PowerShellDataFile -Path $Fixtures.ManifestPath).GUID | Should -Be '220fdbee-bea7-4951-9375-f6e76bd981b4'
+        }
+    }
+
+    Context 'CHANGELOG updates' {
+        BeforeEach { $Fixtures = New-Fixtures }
+        AfterEach { Remove-Fixtures $Fixtures }
+
+        It 'Prepends the new entry above existing entries' {
+            & $Script -Version '1.173.0' -ReleaseNotes "### Features`n- Added X" `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21'
+            $Content = Get-Content $Fixtures.ChangelogPath -Raw
+            $New = $Content.IndexOf('## [1.173.0]')
+            $Old = $Content.IndexOf('## [1.172.2]')
+            $New | Should -BeGreaterThan 0
+            $New | Should -BeLessThan $Old
+        }
+
+        It 'Keeps the changelog header intact' {
+            & $Script -Version '1.173.0' -ReleaseNotes 'notes' `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21'
+            Get-Content $Fixtures.ChangelogPath -Raw | Should -BeLike '# Changelog*'
+        }
+    }
+
+    Context 'Validation' {
+        BeforeEach { $Fixtures = New-Fixtures }
+        AfterEach { Remove-Fixtures $Fixtures }
+
+        It 'Throws for a non-three-part version' {
+            { & $Script -Version '1.2' -ReleaseNotes 'notes' `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath } |
+                Should -Throw '*three-part version*'
+        }
+
+        It 'Throws for empty release notes' {
+            { & $Script -Version '1.173.0' -ReleaseNotes '   ' `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath } |
+                Should -Throw '*must carry notes*'
+        }
+    }
+
+    Context '-WhatIf' {
+        BeforeEach { $Fixtures = New-Fixtures }
+        AfterEach { Remove-Fixtures $Fixtures }
+
+        It 'Leaves the manifest and changelog untouched' {
+            $ManifestBefore = Get-Content $Fixtures.ManifestPath -Raw
+            $ChangelogBefore = Get-Content $Fixtures.ChangelogPath -Raw
+
+            & $Script -Version 'v1.173.0' -ReleaseNotes "### Features`n- Added X" `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21' -WhatIf
+
+            Get-Content $Fixtures.ManifestPath -Raw | Should -Be $ManifestBefore
+            Get-Content $Fixtures.ChangelogPath -Raw | Should -Be $ChangelogBefore
+        }
+    }
+}


### PR DESCRIPTION
## Context

`GitlabCli` ships to two places: the module to the PowerShell Gallery, and a container image to GHCR. Until now CI published the module on every change under `src/` that landed on `main`, and took the version from whatever `ModuleVersion` happened to be hand-written in `GitlabCli.psd1`.

That coupling is the bug. The trigger (a src change) and the version (a hand edit) are two separate things a human has to keep in sync, so merging any src change without also bumping the manifest makes CI try to publish a version the Gallery already has. It answers `409`, and the Publish Module job goes red on `main`.

This gives the version one trigger the maintainer controls. Publishing a GitHub Release is now the only thing that publishes, and the release object carries both halves: the tag is the version, the body is the release notes. CI reads them, writes them into the manifest, prepends a dated `CHANGELOG.md` entry, publishes, and commits the manifest and changelog back to `main`.

The job graph gets reshaped along the way, since the old `release-gate` was doing two unrelated jobs: gating docs on a path filter, and gating publishes on a src filter.

```mermaid
%%{ init: { 'look': 'handDrawn' } }%%
flowchart LR
    subgraph before["before"]
        direction TB
        B1["push to main"] --> B2["release-gate"]
        B2 -->|"src changed"| B3["publish-module"]
        B2 --> B4["publish-docker"]
        B2 -->|"docs changed"| B5["publish-docs"]
    end

    subgraph after["after"]
        direction TB
        A1["push to main"] --> A2["docs-gate"]
        A2 -->|"docs changed"| A3["publish-docs"]
        A4["release published"] --> A5["release"]
        A5 --> A6["module + image"]
    end
```

Docker moves with it, from tagging every push to tagging the released version and `latest`.

## Review guide

- **Start here: the `release` job.** [`ci.yml` R200-R298](https://github.com/chris-peterson/pwsh-gitlab/pull/161/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR200) is the whole new publish path, replacing the old `publish-module` + `publish-docker` pair.
- **The step order is load-bearing.** The [commit-back](https://github.com/chris-peterson/pwsh-gitlab/pull/161/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR285) runs *after* both publishes. See Approach below.
- **The manifest/changelog editor.** [`build/Update-ReleaseArtifacts.ps1`](https://github.com/chris-peterson/pwsh-gitlab/pull/161/files#diff-229ee19bf76220f4b0bcf3e61044a661d5fbb00da71e52acfd40603c49ca1a13R1) does the version/notes surgery. The `ReleaseNotes` swap uses a `MatchEvaluator` [at R61](https://github.com/chris-peterson/pwsh-gitlab/pull/161/files#diff-229ee19bf76220f4b0bcf3e61044a661d5fbb00da71e52acfd40603c49ca1a13R61) so a `$` in someone's release notes isn't treated as a regex substitution, and it [re-parses the manifest](https://github.com/chris-peterson/pwsh-gitlab/pull/161/files#diff-229ee19bf76220f4b0bcf3e61044a661d5fbb00da71e52acfd40603c49ca1a13R70) afterward rather than trusting the edit.
- **Two guards worth a glance.** The release job spells out [`fork == false`](https://github.com/chris-peterson/pwsh-gitlab/pull/161/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR203), where the old publish jobs picked it up by depending on `release-gate`. The image tag comes from [`type=semver`](https://github.com/chris-peterson/pwsh-gitlab/pull/161/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR264) so it reads `1.173.0` and matches `ModuleVersion` rather than carrying the tag's `v`.
- **Skim-level.** [`docs-gate`](https://github.com/chris-peterson/pwsh-gitlab/pull/161/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR183) is the old `release-gate` with the src filter removed; PSScriptAnalyzer now covers `build/` alongside `src/` in [CI](https://github.com/chris-peterson/pwsh-gitlab/pull/161/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR91) and the [justfile](https://github.com/chris-peterson/pwsh-gitlab/pull/161/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R16); `CHANGELOG.md` is seeded with the current `1.172.2` entry so the first real release has something to prepend to.

## Approach & trade-offs

**CI pushes a commit to `main`.** The alternative is to keep hand-bumping `ModuleVersion` in a PR before cutting the release. The commit-back costs one bot commit per release and needs write access to `main`, and buys a manifest that always matches what actually shipped without a human keeping two places in sync. The push uses the built-in `GITHUB_TOKEN`. If `main` ever becomes a protected branch, that token needs explicit permission to push to it.

**Publish first, commit last.** Both orderings can fail halfway. Committing first and failing to publish leaves `main` with a `Release v1.x.y` commit and a CHANGELOG entry for a version nobody can install, and that doesn't self-heal; someone has to hand-remove the entry. Publishing first and failing to commit leaves `main`'s manifest stale, which the next release fixes on its own, because the version comes from that release's tag rather than from the manifest. So the recoverable failure is the one worth choosing.

**The release job checks out `main`, not the tag.** It has to, to commit back, since you can't push from a detached tag ref. The consequence is that the gates run against the tag while the publish runs from `main`, so a tag behind `main` would publish code the gates never checked. Documented in [CONTRIBUTING](https://github.com/chris-peterson/pwsh-gitlab/pull/161/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R93): cut releases from a tag at `main`'s HEAD.

## Testing

[8 Pester tests](https://github.com/chris-peterson/pwsh-gitlab/pull/161/files#diff-9d126b6b8f890aa3134b24ad86ae06129dfab4adc9bb40bc85d5fef9a040ab21R1) cover the script against a fixture manifest: version normalization, verbatim notes replacement (including a literal `$`), the manifest still parsing afterward, changelog prepend order, both validation throws, and that `-WhatIf` leaves both files untouched. Suite is 291 green; analyzer clean on `src/` and `build/`.

The pipeline itself can't be exercised before merge. The `release` job only runs on a published release, so its first real execution is the first release cut after this lands, and the `GITHUB_TOKEN` push to `main` is the part of it that has never run.
