### PR TITLE
Make CONTRIBUTING's just recipes resolve

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,7 @@ We use two tools for security and code quality:
 | [CodeQL](https://codeql.github.com/) | Security vulnerability scanning | CI only |
 
 ```sh
-just lint           # Run PSScriptAnalyzer locally
-just lint-verbose   # Show detailed results
+just lint   # Run PSScriptAnalyzer locally
 ```
 
 Configuration is in `PSScriptAnalyzerSettings.ps1`.

--- a/justfile
+++ b/justfile
@@ -3,6 +3,9 @@
 # :all-the-things!:
 default: test lint help
 
+# Pre-commit gate: tests + lint, without regenerating help
+check: test lint
+
 test:
     #!/usr/bin/env pwsh
     Import-Module Pester


### PR DESCRIPTION
## Context

`CONTRIBUTING.md` walks a new contributor through the local workflow, and two of the commands it tells them to run aren't recipes in the justfile. Step 4 of "Making Changes" says to run `just check` before opening a PR; the Security Analysis section offers `just lint-verbose` for detailed results. Both fail with an unknown-recipe error the first time someone follows the guide.

So: add `check`, and drop the `lint-verbose` mention.

Independent of #161, which touches the same two files in different places (the analyzer's path list and the Releasing section). No ordering between them.

## Review guide

- [`justfile` R7](https://github.com/chris-peterson/pwsh-gitlab/pull/162/files#diff-deb9bb56fb122db0b605aa5b63f95a4665c905b18dd670e1fa6c877576a94ff1R7): `check: test lint`, the gate CONTRIBUTING already describes. Not an alias for `default`, which also runs `help` and so rewrites the generated docs rather than checking them.
- [`CONTRIBUTING.md` R66](https://github.com/chris-peterson/pwsh-gitlab/pull/162/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R66): the `lint-verbose` line comes out.

## Approach & trade-offs

**Dropped `lint-verbose` rather than implementing it.** `just lint` already prints the full PSScriptAnalyzer result table, so a verbose variant has nothing distinct left to show. Writing a recipe to satisfy the doc would mean inventing a behavior difference that isn't there, so the docs move to match the tool instead.
