### PR TITLE
Work around PowerShell rel-link auth defect

### DIFF
--- a/src/GitlabCli/Private/Functions/PaginationHelpers.ps1
+++ b/src/GitlabCli/Private/Functions/PaginationHelpers.ps1
@@ -58,3 +58,39 @@ function Resolve-GitlabMaxPages {
     Write-Debug "MaxPages: $MaxPages"
     $MaxPages
 }
+
+<#
+.SYNOPSIS
+Tests whether the running PowerShell drops the Authorization header when following rel links.
+
+.DESCRIPTION
+Per https://github.com/PowerShell/PowerShell/issues/27861, Invoke-RestMethod's -FollowRelLink
+applies redirect authorization-stripping to rel-link follows, so every page after the first
+is requested anonymously. GitLab answers those anonymously rather than rejecting them, and
+the caller gets a partial result with no error.
+
+The 2026-08-14 servicing patches landed it on three lines at once, and no fix has shipped on
+any of them, so each range is open-ended: a later patch on an affected line still carries it.
+Give a line an upper bound as its fix ships, and drop this function (and Invoke-GitlabApi's
+manual page walk) once every affected version is out of circulation.
+
+Preview and 7.7+ builds are clean today only because the change went straight onto the
+servicing branches. If it is forward-ported, they join the table.
+#>
+function Test-PowerShellRelLinkDefect {
+    [OutputType([bool])]
+    param()
+
+    $FirstAffected = @{
+        '7.4' = [version]'7.4.19'
+        '7.5' = [version]'7.5.10'
+        '7.6' = [version]'7.6.5'
+    }
+
+    $PSVersion = $PSVersionTable.PSVersion
+    $Floor     = $FirstAffected["$($PSVersion.Major).$($PSVersion.Minor)"]
+    if (-not $Floor) {
+        return $false
+    }
+    [version]::new($PSVersion.Major, $PSVersion.Minor, $PSVersion.Patch) -ge $Floor
+}

--- a/src/GitlabCli/Utilities.psm1
+++ b/src/GitlabCli/Utilities.psm1
@@ -94,7 +94,9 @@ function Invoke-GitlabApi {
     if (-not [string]::IsNullOrWhiteSpace($Proxy)) {
         Write-Verbose "Using proxy $Proxy..."
     }
-    if($MaxPages -gt 1) {
+    $Paginate  = $MaxPages -gt 1 -and -not $OutFile
+    $WalkPages = $Paginate -and (Test-PowerShellRelLinkDefect)
+    if ($Paginate -and -not $WalkPages) {
         $RestMethodParams.FollowRelLink        = $true
         $RestMethodParams.MaximumFollowRelLink = $MaxPages
     }
@@ -107,15 +109,49 @@ function Invoke-GitlabApi {
 
     if ($HttpMethod -eq 'GET' -or $PSCmdlet.ShouldProcess($RestMethodParams.Uri, $HostOutput)) {
         Write-Verbose "Request: $HostOutput"
-        $Result = Invoke-RestMethod @RestMethodParams
-        Write-Verbose "Response: $($Result | ConvertTo-Json -Depth 10)"
-        if($MaxPages -gt 1) {
-            # Unwrap pagination container
-            $Result | ForEach-Object {
-                Write-Output $_
+        if ($WalkPages) {
+            # Workaround for https://github.com/PowerShell/PowerShell/issues/27861 (see
+            # Test-PowerShellRelLinkDefect): on affected versions -FollowRelLink fetches every
+            # page after the first without our Authorization header, and a group of 43 projects
+            # comes back as 39 with no error. Walking X-Next-Page ourselves keeps the header on
+            # each request, and X-Total gives us something to check the walk against.
+            $PageUri  = $RestMethodParams.Uri
+            $Appender = $PageUri.Contains('?') ? '&' : '?'
+            $Page     = 1
+            $Yielded  = 0
+            $Total    = $null
+            while ($Page -le $MaxPages) {
+                $RestMethodParams.Uri = "$PageUri$($Appender)page=$Page"
+                $Response = Invoke-WebRequest @RestMethodParams
+                $Response.Content | ConvertFrom-Json | ForEach-Object {
+                    $Yielded++
+                    Write-Output $_
+                }
+                if ($null -eq $Total) {
+                    $Total = $Response.Headers.'X-Total' | Select-Object -First 1
+                }
+                $NextPage = $Response.Headers.'X-Next-Page' | Select-Object -First 1
+                if ([string]::IsNullOrWhiteSpace($NextPage)) {
+                    break
+                }
+                $Page = [int]$NextPage
+            }
+            # A short walk is worth saying out loud: it reads downstream as "the group has
+            # fewer projects", not "the fetch came up short".
+            if ($null -ne $Total -and $Page -le $MaxPages -and $Yielded -lt [int]$Total) {
+                Write-Warning "$Path returned $Yielded of $Total record(s)"
             }
         } else {
-            Write-Output $Result
+            $Result = Invoke-RestMethod @RestMethodParams
+            Write-Verbose "Response: $($Result | ConvertTo-Json -Depth 10)"
+            if ($Paginate) {
+                # Unwrap pagination container
+                $Result | ForEach-Object {
+                    Write-Output $_
+                }
+            } else {
+                Write-Output $Result
+            }
         }
     } else {
         Write-Host "Parameters: $HostOutput"

--- a/tests/Invoke-GitlabApi.Tests.ps1
+++ b/tests/Invoke-GitlabApi.Tests.ps1
@@ -1,0 +1,145 @@
+BeforeAll {
+    $TestModuleName = "Utilities"
+    Get-Module -Name $TestModuleName -All | Remove-Module -Force -ErrorAction SilentlyContinue
+
+    Import-Module (New-Module -Name $TestModuleName -ScriptBlock ([scriptblock]::Create(
+        @(
+            Get-Content "$PSScriptRoot/../src/GitlabCli/Private/Globals.ps1" -Raw
+            Get-Content "$PSScriptRoot/../src/GitlabCli/Private/Functions/StringHelpers.ps1" -Raw
+            Get-Content "$PSScriptRoot/../src/GitlabCli/Private/Functions/PaginationHelpers.ps1" -Raw
+            Get-Content "$PSScriptRoot/../src/GitlabCli/Utilities.psm1" -Raw
+        ) -join "`n"))) -Force
+
+    function global:Resolve-GitlabSite {
+        param([string]$SiteUrl)
+        [PSCustomObject]@{ Url = 'https://gitlab.example.com'; AccessToken = 'token' }
+    }
+
+    # Three pages of 20/20/3, the shape that exposed the paging defect: -FollowRelLink
+    # returned 39 of the 43 because pages 2 and 3 were fetched without the Authorization
+    # header.
+    $global:TestPages = @{
+        1 = @{ Records = 1..20;  Next = '2' }
+        2 = @{ Records = 21..40; Next = '3' }
+        3 = @{ Records = 41..43; Next = ''  }
+    }
+}
+
+AfterAll {
+    Remove-Item function:global:Resolve-GitlabSite -ErrorAction SilentlyContinue
+    Remove-Variable -Name TestPages -Scope Global -ErrorAction SilentlyContinue
+}
+
+Describe 'Invoke-GitlabApi' {
+
+    BeforeEach {
+        Mock -ModuleName Utilities Invoke-WebRequest {
+            $RequestedPage = 1
+            if ($Uri -match 'page=(\d+)') { $RequestedPage = [int]$Matches[1] }
+            $Slice = $global:TestPages[$RequestedPage]
+            if (-not $Slice) { $Slice = @{ Records = @(); Next = '' } }
+            [PSCustomObject]@{
+                Content = ($Slice.Records | ForEach-Object { @{ id = $_ } } | ConvertTo-Json)
+                Headers = @{
+                    'X-Total'     = @('43')
+                    'X-Next-Page' = @($Slice.Next)
+                }
+            }
+        }
+        Mock -ModuleName Utilities Invoke-RestMethod { @() }
+        Mock -ModuleName Utilities Test-PowerShellRelLinkDefect { $true }
+    }
+
+    Context 'When the result spans several pages' {
+        It 'Returns every record' {
+            $Result = Invoke-GitlabApi GET 'groups/1/projects' -MaxPages 100
+            $Result.Count | Should -Be 43
+        }
+
+        It 'Returns the records that sit at a page boundary' {
+            $Ids = Invoke-GitlabApi GET 'groups/1/projects' -MaxPages 100 |
+                Select-Object -ExpandProperty id
+            21, 22, 23, 24 | ForEach-Object { $Ids | Should -Contain $_ }
+        }
+
+        It 'Requests each page once' {
+            $null = Invoke-GitlabApi GET 'groups/1/projects' -MaxPages 100
+            Should -Invoke -ModuleName Utilities Invoke-WebRequest -Times 3 -Exactly
+        }
+    }
+
+    Context 'When MaxPages is lower than the number of pages' {
+        It 'Stops at MaxPages' {
+            $Result = Invoke-GitlabApi GET 'groups/1/projects' -MaxPages 2
+            $Result.Count | Should -Be 40
+        }
+    }
+
+    Context 'When only one page is asked for' {
+        It 'Does not walk pages' {
+            $null = Invoke-GitlabApi GET 'groups/1/projects'
+            Should -Invoke -ModuleName Utilities Invoke-WebRequest -Times 0 -Exactly
+            Should -Invoke -ModuleName Utilities Invoke-RestMethod -Times 1 -Exactly `
+                -ParameterFilter { $Uri -notmatch 'page=' }
+        }
+    }
+
+    Context 'When the running PowerShell follows rel links correctly' {
+        BeforeEach {
+            Mock -ModuleName Utilities Test-PowerShellRelLinkDefect { $false }
+        }
+
+        It 'Lets Invoke-RestMethod follow the rel links' {
+            $null = Invoke-GitlabApi GET 'groups/1/projects' -MaxPages 100
+            Should -Invoke -ModuleName Utilities Invoke-WebRequest -Times 0 -Exactly
+            Should -Invoke -ModuleName Utilities Invoke-RestMethod -Times 1 -Exactly `
+                -ParameterFilter { $FollowRelLink -and $MaximumFollowRelLink -eq 100 }
+        }
+
+        It 'Unwraps the pages Invoke-RestMethod returns' {
+            Mock -ModuleName Utilities Invoke-RestMethod {
+                1..3 | ForEach-Object { , @(@{ id = $_ }) }
+            }
+            $Result = Invoke-GitlabApi GET 'groups/1/projects' -MaxPages 100
+            $Result.Count | Should -Be 3
+        }
+    }
+}
+
+Describe 'Test-PowerShellRelLinkDefect' {
+    It 'Flags <_>, a servicing patch the defect shipped in' -ForEach @(
+        '7.4.19', '7.5.10', '7.6.5'
+    ) {
+        InModuleScope Utilities -Parameters @{ Version = $_ } {
+            $PSVersionTable = @{ PSVersion = [Management.Automation.SemanticVersion]$Version }
+            Test-PowerShellRelLinkDefect | Should -BeTrue
+        }
+    }
+
+    It 'Flags <_>, a later patch on an affected line' -ForEach @(
+        '7.4.20', '7.5.11', '7.6.6'
+    ) {
+        InModuleScope Utilities -Parameters @{ Version = $_ } {
+            $PSVersionTable = @{ PSVersion = [Management.Automation.SemanticVersion]$Version }
+            Test-PowerShellRelLinkDefect | Should -BeTrue
+        }
+    }
+
+    It 'Clears <_>, which predates the defect on its line' -ForEach @(
+        '7.4.18', '7.5.9', '7.6.4', '7.5.0'
+    ) {
+        InModuleScope Utilities -Parameters @{ Version = $_ } {
+            $PSVersionTable = @{ PSVersion = [Management.Automation.SemanticVersion]$Version }
+            Test-PowerShellRelLinkDefect | Should -BeFalse
+        }
+    }
+
+    It 'Clears <_>, a line the defect never landed on' -ForEach @(
+        '7.3.12', '7.7.0-preview.2', '7.9.0-preview.1'
+    ) {
+        InModuleScope Utilities -Parameters @{ Version = $_ } {
+            $PSVersionTable = @{ PSVersion = [Management.Automation.SemanticVersion]$Version }
+            Test-PowerShellRelLinkDefect | Should -BeFalse
+        }
+    }
+}


### PR DESCRIPTION
## Context

`Invoke-GitlabApi` pages the GitLab API with `Invoke-RestMethod -FollowRelLink`, which is how every `-All` / `-Recurse` cmdlet in the module reads more than one page. The 2026-08-14 PowerShell servicing patches (7.4.19 LTS, 7.5.10, 7.6.5) extended redirect authorization-stripping to rel-link follows, so page 1 goes out authenticated and every page after it goes out anonymously. GitLab serves those anonymous requests rather than rejecting them, so the caller gets a visibility-filtered subset with HTTP 200 and no warning: `Get-GitlabProject -GroupId <group> -Recurse -All` returned 39 of a group's 43 projects, silently dropping the 4 internal ones. Upstream: PowerShell/PowerShell#27861.

This walks `X-Next-Page` directly on affected versions, which keeps the header on every request, and warns when the walk yields fewer records than `X-Total`. Unaffected versions keep the `-FollowRelLink` path untouched.

## Review guide

**Critical path**
- [`src/GitlabCli/Utilities.psm1:112`](https://github.com/chris-peterson/pwsh-gitlab/pull/163/changes#diff-bcad0c863b627b9e28cb755bd24ac1be9ab715a01e6750820f02009a80ec2c3cR112) — the manual page walk; a mistake here reads as missing data, not as an error
- [`src/GitlabCli/Private/Functions/PaginationHelpers.ps1:84`](https://github.com/chris-peterson/pwsh-gitlab/pull/163/changes#diff-e6abeebc35575e9131a8a29ac254a321476a4718b3a6329774990bc164c46ec3R84) — the affected-version table, and the only thing to edit as fixes ship

**Integration points**
- [`src/GitlabCli/Utilities.psm1:98`](https://github.com/chris-peterson/pwsh-gitlab/pull/163/changes#diff-bcad0c863b627b9e28cb755bd24ac1be9ab715a01e6750820f02009a80ec2c3cR98) — the branch point; `-OutFile` now also stays off the paging path
- [`src/GitlabCli/Utilities.psm1:142`](https://github.com/chris-peterson/pwsh-gitlab/pull/163/changes#diff-bcad0c863b627b9e28cb755bd24ac1be9ab715a01e6750820f02009a80ec2c3cR142) — the short-walk warning

**Ancillary**
- [`tests/Invoke-GitlabApi.Tests.ps1:87`](https://github.com/chris-peterson/pwsh-gitlab/pull/163/changes#diff-d591d0ed696b8a1b3446369711f7fd4414ec58ec92431ca7e308f97bf0de1cabR87) — the unaffected-version branch, which nothing else exercises on a 7.6.5 dev box
- [`tests/Invoke-GitlabApi.Tests.ps1:119`](https://github.com/chris-peterson/pwsh-gitlab/pull/163/changes#diff-d591d0ed696b8a1b3446369711f7fd4414ec58ec92431ca7e308f97bf0de1cabR119) — version-table coverage

## Approach & trade-offs

The affected set is a **per-line floor with no upper bound** (`7.4` ≥ 7.4.19, `7.5` ≥ 7.5.10, `7.6` ≥ 7.6.5) rather than an exact list of the three versions that shipped it. No fix has landed on any servicing line, and `release/v7.4.20` carries the change today, so an exact list goes stale the moment the next patch ships, and it goes stale in the defect's own direction: reading short with no error. An open floor errs the other way: it walks pages on a version that may no longer need it, which costs a few extra requests and nothing else.

Preview and 7.7+ builds are clean because the change went onto the servicing branches only. If it gets forward-ported, they become another row.

Simplification stays a one-line edit either way: bound a line as its fix ships, and delete `Test-PowerShellRelLinkDefect` along with the walk once every affected version is out of circulation.

## Validation

- [x] **Exercised against the affected instance** — the self-managed GitLab group that surfaced this (43 projects: 39 public, 4 internal), on PowerShell 7.6.5 — observed: `Get-GitlabProject -GroupId <group> -Recurse -All` returns all 43, against 39 on `main`
