### PR TITLE
Source release notes from CHANGELOG's Unreleased

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,11 +230,9 @@ jobs:
           Set-PSRepository PSGallery -InstallationPolicy Trusted
           Install-Module -Name Microsoft.PowerShell.PlatyPS -Force -Scope CurrentUser
 
-      - name: Plumb version and release notes into the manifest and changelog
+      - name: Promote the changelog's Unreleased section into this version
         shell: pwsh
-        env:
-          RELEASE_NOTES: ${{ github.event.release.body }}
-        run: ./build/Update-ReleaseArtifacts.ps1 -Version $env:VERSION -ReleaseNotes $env:RELEASE_NOTES
+        run: ./build/Update-ReleaseArtifacts.ps1 -Version $env:VERSION -NotesOutputPath "$env:RUNNER_TEMP/release-notes.md"
 
       - name: Export MAML help
         shell: pwsh
@@ -279,6 +277,11 @@ jobs:
           subject-name: ${{ env.IMAGE_ID }}
           subject-digest: ${{ steps.build.outputs.digest }}
           push-to-registry: true
+
+      - name: Set the release body to the promoted notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${VERSION}" --notes-file "${RUNNER_TEMP}/release-notes.md"
 
       # Last, so a failed publish leaves main without a commit claiming a
       # release that never shipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to GitlabCli are recorded here, newest first.
 
+## [Unreleased]
+
 ## [1.172.2] - 2026-06-29
 
 ### Bug Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,23 +70,28 @@ Configuration is in `PSScriptAnalyzerSettings.ps1`.
 
 ## Releasing
 
-Releases are driven by [GitHub Releases](https://github.com/chris-peterson/pwsh-gitlab/releases). Publishing a release is the trigger; the release object carries the version and the notes:
+`CHANGELOG.md` keeps an `## [Unreleased]` section at the top, and that section is where release notes come from. Appending to it as you work is welcome but not required; whoever cuts the release reviews it and backfills whatever is missing.
+
+Releases are driven by [GitHub Releases](https://github.com/chris-peterson/pwsh-gitlab/releases). Publishing a release is the trigger; the tag carries the version:
 
 - The **tag** is the version, `v`-prefixed (e.g. `v1.173.0`). CI strips the `v` for both `ModuleVersion` and the image tag, so both read `1.173.0`.
-- The **release body** becomes the release notes.
+- The **notes** are whatever `Unreleased` holds at that moment. The release body you type is replaced with them, so leaving it blank is fine.
 
 On publish, the `release` job:
 
-1. Writes the version into `GitlabCli.psd1` `ModuleVersion` and the body into `ReleaseNotes`, and prepends a dated section to `CHANGELOG.md`.
+1. Promotes `Unreleased` into a dated `## [<version>]` section, leaves a fresh empty `Unreleased` behind, and writes that same text into `GitlabCli.psd1` `ModuleVersion` and `ReleaseNotes`.
 2. Publishes the module to the PowerShell Gallery and the image to GHCR, tagged with the version and `latest`.
-3. Commits the manifest and changelog back to `main`.
+3. Sets the GitHub Release body to the promoted notes, so the releases page reads the same as the changelog.
+4. Commits the manifest and changelog back to `main`.
+
+Dispatching a release with an empty `Unreleased` fails the job, so record what changed before publishing.
 
 The commit-back runs last so that a failed publish leaves `main` without a commit claiming a release that never shipped.
 
 To preview the manifest and changelog edits a release will make, run the script locally with `-WhatIf`:
 
 ```powershell
-./build/Update-ReleaseArtifacts.ps1 -Version v1.173.0 -ReleaseNotes "### Bug Fixes`n- ..." -WhatIf
+./build/Update-ReleaseArtifacts.ps1 -Version v1.173.0 -WhatIf
 ```
 
 Cut releases from a tag at `main`'s HEAD. The test, security, and docs gates run against the tag, but the `release` job checks out `main` (it has to, to commit the version bump back), so a tag behind `main` publishes `main`'s code rather than the code the gates checked.
@@ -100,8 +105,9 @@ The commit-back uses the built-in `GITHUB_TOKEN`. If `main` becomes a protected 
 3. Make your changes
 4. Run `just check` to verify tests pass and no lint errors
 5. Run `just help-update` if you added/modified cmdlets
-6. Commit your changes
-7. Open a Pull Request
+6. Add a line under `## [Unreleased]` in `CHANGELOG.md` if the change is worth a release note
+7. Commit your changes
+8. Open a Pull Request
 
 ## Code Style
 

--- a/build/Update-ReleaseArtifacts.ps1
+++ b/build/Update-ReleaseArtifacts.ps1
@@ -1,15 +1,20 @@
 <#
 .SYNOPSIS
-    Plumbs a release version and notes into the module manifest and CHANGELOG.
+    Promotes CHANGELOG's Unreleased section into a released version.
 
 .DESCRIPTION
-    Given a version and release notes (typically from a published GitHub
-    Release), sets ModuleVersion and ReleaseNotes in GitlabCli.psd1 and prepends
-    a dated section to CHANGELOG.md. Run by the release workflow before
-    publishing, and locally to preview the changes a release will make.
+    Reads the accumulated "## [Unreleased]" section of CHANGELOG.md, moves it
+    under a dated "## [<version>]" heading with a fresh Unreleased left behind,
+    and writes the same text into ModuleVersion and ReleaseNotes in
+    GitlabCli.psd1. Run by the release workflow before publishing, and locally
+    to preview the changes a release will make.
+
+    -NotesOutputPath additionally writes the promoted text on its own, which the
+    release workflow hands to `gh release edit` so the releases page carries the
+    same notes.
 
 .EXAMPLE
-    ./build/Update-ReleaseArtifacts.ps1 -Version v1.173.0 -ReleaseNotes "### Features`n- Added X"
+    ./build/Update-ReleaseArtifacts.ps1 -Version v1.173.0
 #>
 [CmdletBinding(SupportsShouldProcess)]
 param(
@@ -18,10 +23,6 @@ param(
     [string]
     $Version,
 
-    [Parameter(Mandatory)]
-    [string]
-    $ReleaseNotes,
-
     [string]
     $Date = (Get-Date -Format 'yyyy-MM-dd'),
 
@@ -29,7 +30,11 @@ param(
     $ManifestPath = (Join-Path $PSScriptRoot '../src/GitlabCli/GitlabCli.psd1'),
 
     [string]
-    $ChangelogPath = (Join-Path $PSScriptRoot '../CHANGELOG.md')
+    $ChangelogPath = (Join-Path $PSScriptRoot '../CHANGELOG.md'),
+
+    # Where to write the promoted notes on their own, for the release body.
+    [string]
+    $NotesOutputPath
 )
 
 $ErrorActionPreference = 'Stop'
@@ -39,9 +44,25 @@ if ($NormalizedVersion -notmatch '^\d+\.\d+\.\d+$') {
     throw "Version '$Version' is not a three-part version (e.g. v1.173.0)."
 }
 
-$Notes = $ReleaseNotes.Trim()
+# --- CHANGELOG: read the Unreleased section ---
+if (-not (Test-Path $ChangelogPath)) {
+    throw "No changelog at $ChangelogPath; a release promotes its notes from that file's '## [Unreleased]' section."
+}
+
+$Changelog = (Get-Content $ChangelogPath -Raw).TrimEnd()
+
+$Unreleased = [regex]::Match($Changelog, '(?m)^##\s+\[Unreleased\].*$')
+if (-not $Unreleased.Success) {
+    throw "No '## [Unreleased]' section in $ChangelogPath; a release promotes its notes from that section."
+}
+
+$BodyStart = $Unreleased.Index + $Unreleased.Length
+$NextSection = [regex]::Match($Changelog.Substring($BodyStart), '(?m)^##\s+\[')
+$BodyLength = if ($NextSection.Success) { $NextSection.Index } else { $Changelog.Length - $BodyStart }
+
+$Notes = $Changelog.Substring($BodyStart, $BodyLength).Trim()
 if (-not $Notes) {
-    throw 'ReleaseNotes is empty; a release must carry notes.'
+    throw "The '## [Unreleased]' section in $ChangelogPath is empty; record what changed there before releasing."
 }
 
 # --- Manifest: ModuleVersion + ReleaseNotes ---
@@ -73,33 +94,24 @@ if ($PSCmdlet.ShouldProcess($ManifestPath, "set ModuleVersion to $NormalizedVers
     }
 }
 
-# --- CHANGELOG: prepend a dated section ---
-$Header = @"
-# Changelog
+# --- CHANGELOG: promote Unreleased to a dated section ---
+$Intro = $Changelog.Substring(0, $Unreleased.Index).TrimEnd()
+$Released = $Changelog.Substring($BodyStart + $BodyLength).TrimEnd()
 
-All notable changes to GitlabCli are recorded here, newest first.
-"@
-
-$Entry = "## [$NormalizedVersion] - $Date`n`n$Notes"
-
-if (Test-Path $ChangelogPath) {
-    $Existing = (Get-Content $ChangelogPath -Raw).TrimEnd()
-    $FirstEntry = $Existing.IndexOf('## [')
-    if ($FirstEntry -ge 0) {
-        $Intro = $Existing.Substring(0, $FirstEntry).TrimEnd()
-        $Rest = $Existing.Substring($FirstEntry).TrimEnd()
-        $Changelog = "$Intro`n`n$Entry`n`n$Rest"
-    } else {
-        $Changelog = "$Existing`n`n$Entry"
-    }
-} else {
-    $Changelog = "$Header`n`n$Entry"
+$Promoted = "## [Unreleased]`n`n## [$NormalizedVersion] - $Date`n`n$Notes"
+$Updated = "$Intro`n`n$Promoted"
+if ($Released) {
+    $Updated = "$Updated`n`n$Released"
 }
 
-if ($PSCmdlet.ShouldProcess($ChangelogPath, "prepend a $NormalizedVersion entry dated $Date")) {
-    [System.IO.File]::WriteAllText($ChangelogPath, "$Changelog`n")
+if ($PSCmdlet.ShouldProcess($ChangelogPath, "promote Unreleased to a $NormalizedVersion section dated $Date")) {
+    [System.IO.File]::WriteAllText($ChangelogPath, "$Updated`n")
+}
+
+if ($NotesOutputPath -and $PSCmdlet.ShouldProcess($NotesOutputPath, 'write the promoted notes')) {
+    [System.IO.File]::WriteAllText($NotesOutputPath, "$Notes`n")
 }
 
 if (-not $WhatIfPreference) {
-    Write-Host "Set ModuleVersion to $NormalizedVersion and recorded CHANGELOG entry for $Date." -ForegroundColor Green
+    Write-Host "Set ModuleVersion to $NormalizedVersion and promoted Unreleased to a CHANGELOG entry dated $Date." -ForegroundColor Green
 }

--- a/tests/Update-ReleaseArtifacts.Tests.ps1
+++ b/tests/Update-ReleaseArtifacts.Tests.ps1
@@ -1,7 +1,10 @@
 BeforeAll {
     $Script = "$PSScriptRoot/../build/Update-ReleaseArtifacts.ps1"
 
-    function New-Fixtures {
+    # A literal '$' in the body guards the verbatim-notes path through both writes.
+    $DefaultUnreleased = "### Features`n- Added `$special"
+
+    function New-Fixtures($Unreleased = $DefaultUnreleased) {
         $Dir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
         New-Item -ItemType Directory -Path $Dir | Out-Null
 
@@ -31,6 +34,10 @@ BeforeAll {
 
 All notable changes to GitlabCli are recorded here, newest first.
 
+## [Unreleased]
+
+$Unreleased
+
 ## [1.172.2] - 2026-06-29
 
 ### Bug Fixes
@@ -56,32 +63,55 @@ Describe 'Update-ReleaseArtifacts' {
         AfterEach { Remove-Fixtures $Fixtures }
 
         It 'Sets ModuleVersion, stripping a leading v' {
-            & $Script -Version 'v1.173.0' -ReleaseNotes "### Features`n- Added X" `
+            & $Script -Version 'v1.173.0' `
                 -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21'
             (Import-PowerShellDataFile -Path $Fixtures.ManifestPath).ModuleVersion | Should -Be '1.173.0'
         }
 
-        It 'Replaces the ReleaseNotes body verbatim, including literal dollar signs' {
-            & $Script -Version '1.173.0' -ReleaseNotes "### Features`n- Added `$special" `
+        It 'Takes its ReleaseNotes from Unreleased, verbatim, including literal dollar signs' {
+            & $Script -Version '1.173.0' `
                 -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21'
             $Notes = (Import-PowerShellDataFile -Path $Fixtures.ManifestPath).PrivateData.PSData.ReleaseNotes
-            $Notes | Should -BeLike '*Added $special*'
-            $Notes | Should -Not -BeLike '*rnebular*'
+            $Notes | Should -Be $DefaultUnreleased
+        }
+
+        It 'Stores the same text the promoted changelog section gets' {
+            & $Script -Version '1.173.0' `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21'
+            $Notes = (Import-PowerShellDataFile -Path $Fixtures.ManifestPath).PrivateData.PSData.ReleaseNotes
+            $Section = [regex]::Match(
+                (Get-Content $Fixtures.ChangelogPath -Raw),
+                '(?s)## \[1\.173\.0\] - 2026-07-21\n\n(?<body>.*?)\n\n## \[1\.172\.2\]')
+            $Section.Groups['body'].Value | Should -Be $Notes
         }
 
         It 'Leaves a manifest PowerShell can still parse' {
-            & $Script -Version '1.173.0' -ReleaseNotes 'notes' `
+            & $Script -Version '1.173.0' `
                 -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21'
             (Import-PowerShellDataFile -Path $Fixtures.ManifestPath).GUID | Should -Be '220fdbee-bea7-4951-9375-f6e76bd981b4'
         }
     }
 
-    Context 'CHANGELOG updates' {
+    Context 'CHANGELOG promotion' {
         BeforeEach { $Fixtures = New-Fixtures }
         AfterEach { Remove-Fixtures $Fixtures }
 
+        It 'Moves the Unreleased body under a dated version heading' {
+            & $Script -Version '1.173.0' `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21'
+            Get-Content $Fixtures.ChangelogPath -Raw |
+                Should -Match ([regex]::Escape("## [1.173.0] - 2026-07-21`n`n$DefaultUnreleased"))
+        }
+
+        It 'Leaves a fresh, empty Unreleased behind' {
+            & $Script -Version '1.173.0' `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21'
+            Get-Content $Fixtures.ChangelogPath -Raw |
+                Should -Match ([regex]::Escape("## [Unreleased]`n`n## [1.173.0]"))
+        }
+
         It 'Prepends the new entry above existing entries' {
-            & $Script -Version '1.173.0' -ReleaseNotes "### Features`n- Added X" `
+            & $Script -Version '1.173.0' `
                 -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21'
             $Content = Get-Content $Fixtures.ChangelogPath -Raw
             $New = $Content.IndexOf('## [1.173.0]')
@@ -91,9 +121,28 @@ Describe 'Update-ReleaseArtifacts' {
         }
 
         It 'Keeps the changelog header intact' {
-            & $Script -Version '1.173.0' -ReleaseNotes 'notes' `
+            & $Script -Version '1.173.0' `
                 -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21'
             Get-Content $Fixtures.ChangelogPath -Raw | Should -BeLike '# Changelog*'
+        }
+    }
+
+    Context '-NotesOutputPath' {
+        BeforeEach { $Fixtures = New-Fixtures }
+        AfterEach { Remove-Fixtures $Fixtures }
+
+        It 'Writes the promoted notes on their own' {
+            $NotesPath = Join-Path $Fixtures.Dir 'release-notes.md'
+            & $Script -Version '1.173.0' -NotesOutputPath $NotesPath `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21'
+            Get-Content $NotesPath -Raw | Should -Be "$DefaultUnreleased`n"
+        }
+
+        It 'Writes nothing under -WhatIf' {
+            $NotesPath = Join-Path $Fixtures.Dir 'release-notes.md'
+            & $Script -Version '1.173.0' -NotesOutputPath $NotesPath -WhatIf `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21'
+            Test-Path $NotesPath | Should -BeFalse
         }
     }
 
@@ -102,15 +151,41 @@ Describe 'Update-ReleaseArtifacts' {
         AfterEach { Remove-Fixtures $Fixtures }
 
         It 'Throws for a non-three-part version' {
-            { & $Script -Version '1.2' -ReleaseNotes 'notes' `
+            { & $Script -Version '1.2' `
                 -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath } |
                 Should -Throw '*three-part version*'
         }
 
-        It 'Throws for empty release notes' {
-            { & $Script -Version '1.173.0' -ReleaseNotes '   ' `
+        It 'Throws when there is no Unreleased section, naming the file' {
+            [System.IO.File]::WriteAllText($Fixtures.ChangelogPath, "# Changelog`n`n## [1.172.2] - 2026-06-29`n`nnotes`n")
+            { & $Script -Version '1.173.0' `
                 -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath } |
-                Should -Throw '*must carry notes*'
+                Should -Throw "*No *Unreleased* section in $($Fixtures.ChangelogPath)*"
+        }
+
+        It 'Throws when the changelog is missing' {
+            [System.IO.File]::Delete($Fixtures.ChangelogPath)
+            { & $Script -Version '1.173.0' `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath } |
+                Should -Throw '*No changelog at*'
+        }
+    }
+
+    Context 'Validation with an empty Unreleased' {
+        BeforeEach { $Fixtures = New-Fixtures '' }
+        AfterEach { Remove-Fixtures $Fixtures }
+
+        It 'Throws, naming the section and the file' {
+            { & $Script -Version '1.173.0' `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath } |
+                Should -Throw "*Unreleased* section in $($Fixtures.ChangelogPath) is empty*"
+        }
+
+        It 'Leaves the manifest untouched' {
+            $ManifestBefore = Get-Content $Fixtures.ManifestPath -Raw
+            { & $Script -Version '1.173.0' `
+                -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath } | Should -Throw
+            Get-Content $Fixtures.ManifestPath -Raw | Should -Be $ManifestBefore
         }
     }
 
@@ -122,7 +197,7 @@ Describe 'Update-ReleaseArtifacts' {
             $ManifestBefore = Get-Content $Fixtures.ManifestPath -Raw
             $ChangelogBefore = Get-Content $Fixtures.ChangelogPath -Raw
 
-            & $Script -Version 'v1.173.0' -ReleaseNotes "### Features`n- Added X" `
+            & $Script -Version 'v1.173.0' `
                 -ManifestPath $Fixtures.ManifestPath -ChangelogPath $Fixtures.ChangelogPath -Date '2026-07-21' -WhatIf
 
             Get-Content $Fixtures.ManifestPath -Raw | Should -Be $ManifestBefore


### PR DESCRIPTION
## Context

`GitlabCli` publishes to the PowerShell Gallery from a `release` job that fires when a GitHub Release is published. That job takes the **release body** as its notes source, writing it into the manifest's `ReleaseNotes` and into a new dated section of `CHANGELOG.md`. Notes therefore have to be authored in the Release form at dispatch time, reconstructed from memory and `git log` by whoever cuts the release, and the changelog can't answer "what's on `main` but unreleased?" because nothing is written there until a release happens.

This inverts the direction. `CHANGELOG.md` carries an `## [Unreleased]` section that accumulates as work lands, and the release *promotes* it: the body moves under a dated `## [<version>]` heading, a fresh empty `Unreleased` is left behind, and the same text goes into the manifest. The version still comes from the release tag, so the semver call stays human. Closes #166. `pwsh-github` and `pwsh-forge` copy whatever shape lands here, so the choices are meant to carry.

## Review guide

**The promotion, and the whole behavior change** — [`build/Update-ReleaseArtifacts.ps1`](https://github.com/chris-peterson/pwsh-gitlab/pull/168/changes#diff-229ee19bf76220f4b0bcf3e61044a661d5fbb00da71e52acfd40603c49ca1a13R101)

**An empty section blocks the release** rather than publishing notes-less, naming the section and the file so the fix is obvious from the job log. It throws before the manifest is touched — [`build/Update-ReleaseArtifacts.ps1`](https://github.com/chris-peterson/pwsh-gitlab/pull/168/changes#diff-229ee19bf76220f4b0bcf3e61044a661d5fbb00da71e52acfd40603c49ca1a13R65)

**The release body becomes an output.** Nobody has to type notes now, so the job backfills the body from the promoted section after publish and before the commit to `main` — [`.github/workflows/ci.yml`](https://github.com/chris-peterson/pwsh-gitlab/pull/168/changes#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR284)

**Appending as you go is welcome, not required** — requiring it turns a one-line fix into a two-file change, and the entry often reads better once the shape has settled. Whoever cuts the release backfills — [`CONTRIBUTING.md`](https://github.com/chris-peterson/pwsh-gitlab/pull/168/changes#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R73)

**Tests** cover promotion, the fresh `Unreleased`, byte-for-byte agreement between the changelog section and `ReleaseNotes`, all three throws, and `-WhatIf` — [`tests/Update-ReleaseArtifacts.Tests.ps1`](https://github.com/chris-peterson/pwsh-gitlab/pull/168/changes#diff-9d126b6b8f890aa3134b24ad86ae06129dfab4adc9bb40bc85d5fef9a040ab21R106)

**The seed** — [`CHANGELOG.md`](https://github.com/chris-peterson/pwsh-gitlab/pull/168/changes#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed) gains an empty `## [Unreleased]`, which the next release backfills before it can publish.

## Approach & trade-offs

`Unreleased` is a merge-conflict surface: several branches appending to the same section will collide. In practice these are one-line additions and the resolution is "keep both", which is the cost of the as-you-go convention.

The release body is **replaced**, not merged, so anything typed into the Release form at dispatch is overwritten by the promoted section. That's what makes "nobody types notes" true; the alternative (leave the body to the author) leaves the releases page blank whenever they don't.
